### PR TITLE
octoprint/util/comm.py: make line number detection more robust

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -819,11 +819,26 @@ class MachineCom(object):
 
 	def _handleResendRequest(self, line):
 		lineToResend = None
-		try:
-			lineToResend = int(line.replace("N:"," ").replace("N"," ").replace(":"," ").split()[-1])
-		except:
-			if "rs" in line:
-				lineToResend = int(line.split()[1])
+
+		# Find the first word on the line that looks like a line
+		# number.  Something "looks like" a line number if it's
+		# an integer, possibly prefixed with N or N:
+		line = line.lstrip("rs")
+		words = line.split()
+		for w in words:
+			if not w.startswith("N"):
+                                continue
+
+                        w = w.replace("N", "")
+			if w.startswith(":"):
+				w = w.replace(":", "")
+			try:
+				lineToResend = int(w)
+			except:
+				pass
+
+			if lineToResend is not None:
+				break
 
 		if lineToResend is not None:
 			self._resendDelta = self._currentLine - lineToResend


### PR DESCRIPTION
When the printer requests a resend, we have to determine which line
number it wants.  The old logic would be confused if there was more
than one number in the line.  Some version of Teacup firmware
request a resend with the format "rs N25 Expected checksum 109".
The new logic detects this format correctly.
