### PR TITLE
More Accurate EstimatedPrintTime and Print time Left + PrintProgress event

### DIFF
--- a/src/octoprint/events.py
+++ b/src/octoprint/events.py
@@ -47,6 +47,7 @@ class Events(object):
 	PRINT_CANCELLED = "PrintCancelled"
 	PRINT_PAUSED = "PrintPaused"
 	PRINT_RESUMED = "PrintResumed"
+	PRINT_PROGRESS = "PrintProgress"
 	ERROR = "Error"
 
 	# print/gcode events
@@ -293,7 +294,7 @@ class CommandTrigger(GenericEventListener):
 	def _executeGcodeCommand(self, command):
 		commands = [command]
 		if isinstance(command, (list, tuple, set)):
-			self.logger.debug("Executing GCode commands: %r" % command)
+			self._logger.debug("Executing GCode commands: %r" % command)
 			commands = list(command)
 		else:
 			self._logger.debug("Executing GCode command: %s" % command)
@@ -330,8 +331,8 @@ class CommandTrigger(GenericEventListener):
 		if "job" in currentData.keys() and currentData["job"] is not None:
 			params["__filename"] = currentData["job"]["file"]["name"]
 			if "progress" in currentData.keys() and currentData["progress"] is not None \
-				and "progress" in currentData["progress"].keys() and currentData["progress"]["progress"] is not None:
-				params["__progress"] = str(round(currentData["progress"]["progress"] * 100))
+				and "completion" in currentData["progress"].keys() and currentData["progress"]["completion"] is not None:
+				params["__progress"] = str(round(currentData["progress"]["completion"], 1))
 
 		# now add the payload keys as well
 		if isinstance(payload, dict):

--- a/src/octoprint/gcodefiles.py
+++ b/src/octoprint/gcodefiles.py
@@ -19,6 +19,9 @@ from octoprint.filemanager.destinations import FileDestinations
 
 from werkzeug.utils import secure_filename
 
+# singleton
+_instance = None
+
 GCODE_EXTENSIONS = ["gcode", "gco", "g"]
 STL_EXTENSIONS = ["stl"]
 SUPPORTED_EXTENSIONS = GCODE_EXTENSIONS + STL_EXTENSIONS
@@ -58,6 +61,11 @@ def genStlFileName(filename):
 	name, ext = filename.rsplit(".", 1)
 	return name + ".stl"
 
+def gcodeManager():
+	global _instance
+	if _instance is None:
+		_instance = GcodeManager()
+	return _instance
 
 class GcodeManager:
 	def __init__(self):

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -140,7 +140,7 @@ class Server():
 		logger = logging.getLogger(__name__)
 
 		eventManager = events.eventManager()
-		gcodeManager = gcodefiles.GcodeManager()
+		gcodeManager = gcodefiles.gcodeManager()
 		printer = Printer(gcodeManager)
 
 		# configure timelapse

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -39,6 +39,7 @@ def getSettings():
 			"movementSpeedY": movementSpeedY,
 			"movementSpeedZ": movementSpeedZ,
 			"movementSpeedE": movementSpeedE,
+			"feedRateMultiply": s.getFloat(["printerParameters", "feedRateMultiply"]),
 			"invertAxes": s.get(["printerParameters", "invertAxes"]),
 			"numExtruders": s.get(["printerParameters", "numExtruders"]),
 			"extruderOffsets": s.get(["printerParameters", "extruderOffsets"]),
@@ -119,6 +120,7 @@ def setSettings():
 			if "movementSpeedY" in data["printer"].keys(): s.setInt(["printerParameters", "movementSpeed", "y"], data["printer"]["movementSpeedY"])
 			if "movementSpeedZ" in data["printer"].keys(): s.setInt(["printerParameters", "movementSpeed", "z"], data["printer"]["movementSpeedZ"])
 			if "movementSpeedE" in data["printer"].keys(): s.setInt(["printerParameters", "movementSpeed", "e"], data["printer"]["movementSpeedE"])
+			if "feedRateMultiply" in data["printer"].keys(): s.setFloat(["printerParameters", "feedRateMultiply"], data["printer"]["feedRateMultiply"])
 			if "invertAxes" in data["printer"].keys(): s.set(["printerParameters", "invertAxes"], data["printer"]["invertAxes"])
 			if "numExtruders" in data["printer"].keys(): s.setInt(["printerParameters", "numExtruders"], data["printer"]["numExtruders"])
 			if "extruderOffsets" in data["printer"].keys(): s.set(["printerParameters", "extruderOffsets"], data["printer"]["extruderOffsets"])

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -395,7 +395,7 @@ class Settings(object):
 		return feedbackControls
 
 	def _getFeedbackControls(self, control=None):
-		if control["type"] == "feedback_command" or control["type"] == "feedback":
+		if control["type"] == "feedback_command":
 			pattern = control["regex"]
 			try:
 				matcher = re.compile(pattern)

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -94,6 +94,7 @@ default_settings = {
 			"z": 200,
 			"e": 300
 		},
+		"feedRateMultiply": 1.0,
 		"pauseTriggers": [],
 		"invertAxes": [],
 		"numExtruders": 1,

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -16,6 +16,7 @@ function SettingsViewModel(loginStateViewModel, usersViewModel) {
     self.printer_movementSpeedY = ko.observable(undefined);
     self.printer_movementSpeedZ = ko.observable(undefined);
     self.printer_movementSpeedE = ko.observable(undefined);
+    self.printer_feedRateMultiply = ko.observable(undefined);
     self.printer_invertAxes = ko.observable(undefined);
     self.printer_numExtruders = ko.observable(undefined);
 
@@ -196,6 +197,7 @@ function SettingsViewModel(loginStateViewModel, usersViewModel) {
         self.printer_movementSpeedY(response.printer.movementSpeedY);
         self.printer_movementSpeedZ(response.printer.movementSpeedZ);
         self.printer_movementSpeedE(response.printer.movementSpeedE);
+        self.printer_feedRateMultiply(response.printer.feedRateMultiply);
         self.printer_invertAxes(response.printer.invertAxes);
         self.printer_numExtruders(response.printer.numExtruders);
         self.printer_extruderOffsets(response.printer.extruderOffsets);
@@ -261,6 +263,7 @@ function SettingsViewModel(loginStateViewModel, usersViewModel) {
                 "movementSpeedY": self.printer_movementSpeedY(),
                 "movementSpeedZ": self.printer_movementSpeedZ(),
                 "movementSpeedE": self.printer_movementSpeedE(),
+                "feedRateMultiply": self.printer_feedRateMultiply(),
                 "invertAxes": self.printer_invertAxes(),
                 "numExtruders": self.printer_numExtruders(),
                 "extruderOffsets": self.printer_extruderOffsets(),

--- a/src/octoprint/templates/settings.jinja2
+++ b/src/octoprint/templates/settings.jinja2
@@ -163,7 +163,13 @@
                                 </div>
                             </div>
                             <!-- /ko -->
-                        </div>
+												</div>
+												<div class="control-group">
+													<label class="control-label" for="settings-feedRateMultiply">Feedrate Multiply</label>
+													<div class="controls">
+														<input type="number" step="0.01" class="input-mini text-right" max="1" data-bind="value: printer_feedRateMultiply" id="settings-feedRateMultiply">
+                          </div>
+												</div>
                         <div class="control-group">
                             <label class="control-label" for="settings-bedSize">Bed Size</label>
                             <div class="controls form-inline" data-bind="ifnot: printer_bedCircular">

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -399,6 +399,7 @@ class MachineCom(object):
 			self._currentFile.start()
 
 			wasPaused = self.isPaused()
+			self._lastProgress = None
 			self._changeState(self.STATE_PRINTING)
 			eventManager().fire(Events.PRINT_STARTED, {
 				"file": self._currentFile.getFilename(),

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -406,7 +406,7 @@ class MachineCom(object):
 				"filename": os.path.basename(self._currentFile.getFilename()),
 				"origin": self._currentFile.getFileLocation()
 			})
-			metadata = gcodeManager().getFileMetadata(filename)
+			metadata = gcodeManager().getFileMetadata(self._currentFile.getFilename())
 			if "gcodeAnalysis" in metadata.keys() and "estimatedPrintTime" in metadata["gcodeAnalysis"].keys():
 				self._estimatedPrintTime = metadata["gcodeAnalysis"]["estimatedPrintTime"]
 

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -406,6 +406,9 @@ class MachineCom(object):
 				"filename": os.path.basename(self._currentFile.getFilename()),
 				"origin": self._currentFile.getFileLocation()
 			})
+			metadata = gcodeManager().getFileMetadata(filename)
+			if "gcodeAnalysis" in metadata.keys() and "estimatedPrintTime" in metadata["gcodeAnalysis"].keys():
+				self._estimatedPrintTime = metadata["gcodeAnalysis"]["estimatedPrintTime"]
 
 			if self.isSdFileSelected():
 				if wasPaused:
@@ -442,10 +445,6 @@ class MachineCom(object):
 			self.sendCommand("M23 %s" % filename)
 		else:
 			self._currentFile = PrintingGcodeFileInformation(filename, self.getOffsets)
-			metadata = gcodeManager().getFileMetadata(filename)
-			if "gcodeAnalysis" in metadata.keys() and "estimatedPrintTime" in metadata["gcodeAnalysis"].keys():
-				self._estimatedPrintTime = metadata["gcodeAnalysis"]["estimatedPrintTime"]
-
 			eventManager().fire(Events.FILE_SELECTED, {
 				"file": self._currentFile.getFilename(),
 				"origin": self._currentFile.getFileLocation()

--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -55,7 +55,7 @@ class gcode(object):
 		totalMoveTimeMinute = 0.0
 		absoluteE = True
 		scale = 1.0
-		feedRateMultiply = 0.65 # little test for simulating Acceleration
+		feedRateMultiply = settings().getFloat(["printerParameters", "feedRateMultiply"]) # 0.6 # little test for simulating Acceleration
 		posAbs = True
 		maxFeedrate = settings().get(["printerParameters", "movementSpeed"])
 		feedRateXY = settings().getFloat(["printerParameters", "movementSpeed", "x"]) * feedRateMultiply
@@ -165,7 +165,7 @@ class gcode(object):
 						if abs(tmp) > maxFeedrate[axiscode[i]]:
 							speedFactor = min(speedFactor, maxFeedrate[axiscode[i]] / abs(tmp))
 					
-					totalMoveTimeMinute += millimeters*speedFactor/feedRateXY;
+					totalMoveTimeMinute += millimeters/(feedRateXY*speedFactor);
 				elif G == 4:	#Delay
 					S = getCodeFloat(line, 'S')
 					if S is not None:
@@ -178,6 +178,7 @@ class gcode(object):
 				elif G == 21:	#Units are mm
 					scale = 1.0
 				elif G == 28:	#Home
+					totalMoveTimeMinute += 0.25 # this takes time too 15 seconds should be ok
 					x = getCodeFloat(line, 'X')
 					y = getCodeFloat(line, 'Y')
 					z = getCodeFloat(line, 'Z')


### PR DESCRIPTION
Hello,

I added a PrintProgress event (e.g. for updating the LCD with the Progress) and made the Printtime estimation and Print Time left more accurate, e.g. (2:54 Hours calculated Printtime, took 2:51 Hours, Print time Left always told me it might end next to 2:53 Hours) I guess this is accurate enough.
Well heating times are not included.

Requirements for this accuracy is:
1. A good feedRateMultiply value in the settings. This value shall compensate the acceleration for me a value of 0.75 made the good estimations from above.
2. The gcode file must have been analysed before Selecting. 
ATTENTION not printing it really must have been analysed before selecting, maybe I change that.

Hope this helps to get better estimations.
