### PR TITLE
Relative path for webcam stream

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -13,6 +13,7 @@ from flask.ext.principal import Principal, Permission, RoleNeed, identity_loaded
 from flask.ext.babel import Babel
 from babel import Locale
 from watchdog.observers import Observer
+from urlparse import urlparse
 
 import os
 import logging
@@ -110,7 +111,11 @@ def index():
 	template_plugin_names = template_plugins.keys()
 
 	settingsWebcamStream = settings().get(["webcam", "stream"])
-	webcamStream = request.headers['Host'].split(":")[0] + settingsWebcamStream if settingsWebcamStream[0] == ":" else settingsWebcamStream
+	if(settingsWebcamStream[0] == ":")
+		urlParsed = urlparse(request.url)
+		webcamStream = urlParsed.scheme + '://' + urlParsed.hostname + settingsWebcamStream
+	else
+		webcamStream = settingsWebcamStream
 
 	return render_template(
 		"index.jinja2",

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -111,10 +111,10 @@ def index():
 	template_plugin_names = template_plugins.keys()
 
 	settingsWebcamStream = settings().get(["webcam", "stream"])
-	if(settingsWebcamStream[0] == ":")
+	if settingsWebcamStream and settingsWebcamStream[0] == ":":
 		urlParsed = urlparse(request.url)
 		webcamStream = urlParsed.scheme + '://' + urlParsed.hostname + settingsWebcamStream
-	else
+	else:
 		webcamStream = settingsWebcamStream
 
 	return render_template(

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -109,9 +109,12 @@ def index():
 	template_plugins = pluginManager.get_implementations(octoprint.plugin.TemplatePlugin)
 	template_plugin_names = template_plugins.keys()
 
+	settingsWebcamStream = settings().get(["webcam", "stream"])
+	webcamStream = request.headers['Host'].split(":")[0] + settingsWebcamStream if settingsWebcamStream[0] == ":" else settingsWebcamStream
+
 	return render_template(
 		"index.jinja2",
-		webcamStream=settings().get(["webcam", "stream"]),
+		webcamStream=webcamStream,
 		enableTimelapse=(settings().get(["webcam", "snapshot"]) is not None and settings().get(["webcam", "ffmpeg"]) is not None),
 		enableGCodeVisualizer=settings().get(["gcodeViewer", "enabled"]),
 		enableTemperatureGraph=settings().get(["feature", "temperatureGraph"]),


### PR DESCRIPTION
If Octoprint server and webcam stream are hosted on the same server there could be a problem
when access is possible from different networks: for example from local network and from internet.

Let assume that octoprint address from local net is **http://192.168.111.22:5000** and from internet **http://octoprint.somedomain.org**. Webcam stream is hosted on the same server on port **4321** and path **/video**.
In this case when you connect to **http://192.168.111.22:5000** the address of webcam stream should be **http://192.168.111.22:4321/video**. When connect to **http://octoprint.somedomain.org** the address of webcam stream should be **http://octoprint.somedomain.org:4321/video**

Now you can specify **:port/path** as a webcam stream address (**:4321/video** in example above) and it will be added to server address depending on how you access to the server. Port with path are removed from octoprint address and port with path for webcam stream are added.