### PR TITLE
Daemon cleans up pidfile when receiving a SIGTERM

### DIFF
--- a/src/octoprint/daemon.py
+++ b/src/octoprint/daemon.py
@@ -53,13 +53,14 @@ class Daemon:
 		os.dup2(se.fileno(), sys.stderr.fileno())
 	
 		# write pidfile
-		signal.signal(signal.SIGTERM,self.delpid)
-
 		pid = str(os.getpid())
 		with open(self.pidfile,'w+') as f:
 			f.write(pid + '\n')
-	
-	def delpid(self, _signo, _stack_frame):
+
+		# register listener for SIGTERM
+		signal.signal(signal.SIGTERM, self.term)
+
+	def term(self, _signo, _stack_frame):
 		os.remove(self.pidfile)
 		sys.exit(0)
 

--- a/src/octoprint/daemon.py
+++ b/src/octoprint/daemon.py
@@ -4,7 +4,7 @@ Generic linux daemon base class for python 3.x
 Originally from http://www.jejik.com/articles/2007/02/a_simple_unix_linux_daemon_in_python/#c35
 """
 
-import sys, os, time, atexit, signal
+import sys, os, time, signal
 
 class Daemon:
 	"""A generic daemon class.
@@ -53,14 +53,15 @@ class Daemon:
 		os.dup2(se.fileno(), sys.stderr.fileno())
 	
 		# write pidfile
-		atexit.register(self.delpid)
+		signal.signal(signal.SIGTERM,self.delpid)
 
 		pid = str(os.getpid())
 		with open(self.pidfile,'w+') as f:
 			f.write(pid + '\n')
 	
-	def delpid(self):
+	def delpid(self, _signo, _stack_frame):
 		os.remove(self.pidfile)
+		sys.exit(0)
 
 	def start(self):
 		"""Start the daemon."""


### PR DESCRIPTION
Changes the behavior of a daemonized OctoPrint to delete its pidfile when receiving a TERM signal. Current behavior would only delete the file upon exit of the separate process that was started to kill the daemon process (using the `--daemon stop` flag).

Compatibility with the existing command line arguments is retained because it was already sending SIGTERM to the daemon process.

Should fix #711.

Note: I didn't touch `scripts/octoprint.init` because I'm not very familiar with the behavior of Debian's init.d, and have limited capability to test any changes.