### PR TITLE
Bugfix for Invalid cross-device link on Linux when /tmp is on another fs

### DIFF
--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -9,6 +9,7 @@ import time
 import re
 import tempfile
 import logging
+import shutil
 from flask import make_response
 
 from octoprint.settings import settings, default_settings
@@ -182,7 +183,8 @@ def safeRename(old, new, throw_error=False):
 				raise e
 	else:
 		# on anything else than windows it's ooooh so much easier...
-		os.rename(old, new)
+		# because of shutil's high level, maybe win32-specific code isn't needed anymore
+		shutil.move(old, new)
 
 
 def silentRemove(file):


### PR DESCRIPTION
Hello. There are fix for #710 and #716 

When octoprint going to move a file from one directory to another on linux, if directories is located on different filesystems, os.rename wouldn't work, raising error "OSError: [Errno 18] Invalid cross-device link". In that pull request it is fixed with changing os.rename into shutil.move

Another effect of changing: shutil.move is high-level operation, which uses os.rename if it is acceptable, so maybe win32-specific code isn't needed with shutil (investigations still needed though).