### PR TITLE
Inherit clean command so that it supports the usual flags.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ versioneer.tag_prefix = ''
 versioneer.parentdir_prefix = ''
 
 from setuptools import setup, find_packages, Command
+from distutils.command.clean import clean as Clean
 import os
 import shutil
 import glob
@@ -26,21 +27,10 @@ def package_data_dirs(source, sub_folders):
 	return dirs
 
 
-class CleanCommand(Command):
-	description = "clean build artifacts"
-	user_options = []
-	boolean_options = []
-
-	def initialize_options(self):
-		pass
-
-	def finalize_options(self):
-		pass
+class CleanCommand(Clean):
 
 	def run(self):
-		if os.path.exists('build'):
-			print "Deleting build directory"
-			shutil.rmtree('build')
+                Clean.run(self)
 		eggs = glob.glob('OctoPrint*.egg-info')
 		for egg in eggs:
 			print "Deleting %s directory" % egg


### PR DESCRIPTION
Debian packaging tools expect setup.py to take the `--all` flag (and its abbreviation, `-a`). This PR meets those needs by subclassing the standard setuptools `clean` command, which supports those flags.

This PR changes the semantics of setup.py slightly compared to previous versions of Octoprint. '--all' now needs to be passed in order to delete everything that is deleted by previous versions. Some additional build files may also be deleted.
