### PR TITLE
Fixed wrapping of icons at Access Control settings page with some translations

### DIFF
--- a/src/octoprint/templates/dialogs/settings/accesscontrol.jinja2
+++ b/src/octoprint/templates/dialogs/settings/accesscontrol.jinja2
@@ -13,7 +13,7 @@
         <td class="settings_users_name"><span data-bind="text: name"></span><span class="muted" data-bind="visible: $root.api_enabled() && apikey"><br /><small>{{ _('API Key') }}: <span data-bind="text: apikey"></span></small></span></td>
         <td class="settings_users_active"><i data-bind="css: { 'icon-check': active, 'icon-check-empty': !active }"></i></td>
         <td class="settings_users_admin"><i data-bind="css: { 'icon-check': admin, 'icon-check-empty': !admin }"></i></td>
-        <td class="settings_users_actions">
+        <td class="settings_users_actions" style="white-space:nowrap">
             <a href="#" class="icon-pencil" title="{{ _('Update User') }}" data-bind="click: function() { $root.users.showEditUserDialog($data); }"></a>&nbsp;|&nbsp;<a href="#" class="icon-key" title="{{ _('Change password') }}" data-bind="click: function() { $root.users.showChangePasswordDialog($data); }"></a>&nbsp;|&nbsp;<a href="#" class="icon-trash" title="{{ _('Delete user') }}" data-bind="click: function() { $root.users.removeUser($data); }"></a>
         </td>
     </tr>


### PR DESCRIPTION
Hello. Working on Russian translation, I have found out that in some reason when table headers are longer than English ones, Action icons heve wrapped to two lines, which looks awful. That pull request should fix that for any translation