### PR TITLE
Fix logger call for gcode multi commands events

### DIFF
--- a/src/octoprint/events.py
+++ b/src/octoprint/events.py
@@ -293,7 +293,7 @@ class CommandTrigger(GenericEventListener):
 	def _executeGcodeCommand(self, command):
 		commands = [command]
 		if isinstance(command, (list, tuple, set)):
-			self.logger.debug("Executing GCode commands: %r" % command)
+			self._logger.debug("Executing GCode commands: %r" % command)
 			commands = list(command)
 		else:
 			self._logger.debug("Executing GCode command: %s" % command)


### PR DESCRIPTION
Missing `_` causes the whole thing to fail.

    Traceback (most recent call last):
      File "/home/pi/OctoPrint/src/octoprint/events.py", line 110, in _work
        listener(event, payload)
      File "/home/pi/OctoPrint/src/octoprint/events.py", line 267, in eventCallback
        self.executeCommand(processedCommand, commandType)
      File "/home/pi/OctoPrint/src/octoprint/events.py", line 275, in executeCommand
        self._executeGcodeCommand(command)
      File "/home/pi/OctoPrint/src/octoprint/events.py", line 296, in _executeGcodeCommand
        self.logger.debug("Executing GCode commands: %r" % command)
    AttributeError: 'CommandTrigger' object has no attribute 'logger'