### PR TITLE
Added option for timelapse on beep (M300) event

### DIFF
--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -27,6 +27,9 @@ def getTimelapseData():
 	if timelapse is not None and isinstance(timelapse, octoprint.timelapse.ZTimelapse):
 		config["type"] = "zchange"
 		config["postRoll"] = timelapse.postRoll()
+	elif timelapse is not None and isinstance(timelapse, octoprint.timelapse.BeepTimelapse):
+		config["type"] = "onbeep"
+		config["postRoll"] = timelapse.postRoll()
 	elif timelapse is not None and isinstance(timelapse, octoprint.timelapse.TimedTimelapse):
 		config["type"] = "timed"
 		config["postRoll"] = timelapse.postRoll()

--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -74,6 +74,8 @@ function PrinterStateViewModel(loginStateViewModel) {
         var type = timelapse["type"];
         if (type == "zchange") {
             return "On Z Change";
+        } else if (type == "onbeep") {
+            return "On Beep (M300)";
         } else if (type == "timed") {
             return "Timed (" + timelapse["options"]["interval"] + "s)";
         } else {

--- a/src/octoprint/templates/index.jinja2
+++ b/src/octoprint/templates/index.jinja2
@@ -531,6 +531,7 @@
                                     <option value="off">Off</option>
                                     <option value="zchange">On Z Change</option>
                                     <option value="timed">Timed</option>
+                                    <option value="onbeep">On Beep (M300)</option>
                                 </select>
 
                                 <label for="webcam_timelapse_postRoll">Timelapse post roll (in rendered seconds)</label>

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -82,6 +82,8 @@ def configureTimelapse(config=None, persist=False):
 		current = None
 	elif "zchange" == type:
 		current = ZTimelapse(postRoll=postRoll)
+	elif "onbeep" == type:
+		current = BeepTimelapse(postRoll=postRoll)
 	elif "timed" == type:
 		interval = 10
 		if "options" in config and "interval" in config["options"]:


### PR DESCRIPTION
I'm new to Git and GitHub, so sorry in advance if this is not the right mechanism for submitting a suggested change.

This modification allows G-code triggered frames for timelapse video.  This allows me to move the print head out of the way and position the XY stage in the same position for each frame, as seen here:
https://www.youtube.com/watch?v=b3LWAffjjic

Because of the firmware command queueing, it is not enough to add M300 to the layer-change G-code.  I added "G4 P100" about 20x prior to the M300 command to force execution and flushing of the X/Y movement prior to the snapshot.  This all happens on the slicing side, not within OctoPrint, but it is necessary to get the results.

Feedback or comments welcome.
