### PR TITLE
Add apiKey to discovery plugin (new param in plugin config and xml template)

### DIFF
--- a/src/octoprint/plugins/discovery/__init__.py
+++ b/src/octoprint/plugins/discovery/__init__.py
@@ -122,6 +122,7 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 		                                                     modelUrl=self._settings.get(["model", "url"]),
 		                                                     serialNumber=self._settings.get(["model", "serial"]),
 		                                                     uuid=self.get_uuid(),
+		                                                     apiKey=self.get_api_key(),
 		                                                     presentationUrl=flask.url_for("index", _external=True)))
 		response.headers['Content-Type'] = 'application/xml'
 		return response
@@ -674,6 +675,9 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 			self._settings.set(["upnpUuid"], upnpUuid)
 			self._settings.save()
 		return upnpUuid
+
+	def get_api_key(self):
+		return self._settings.get(["apiKey"])
 
 	def get_instance_name(self):
 		name = self._settings.globalGet(["appearance", "name"])

--- a/src/octoprint/plugins/discovery/templates/discovery.xml.jinja2
+++ b/src/octoprint/plugins/discovery/templates/discovery.xml.jinja2
@@ -18,5 +18,6 @@
         <serviceList>
         </serviceList>
         <presentationURL>{{ presentationUrl }}</presentationURL>
+        <apiKey>{{ apiKey }}</apiKey>
     </device>
 </root>


### PR DESCRIPTION
Adding the apiKey as a configuration option for the discovery plugin, which is then sent in the discover.xml template, to enable an application to be able to control OctoPrint after auto discovery.

It would be better if the apiKey could be pulled directly from the regular location in the configuration, but it appears that the plugins are only able to see their specific config.

On the other hand, it is a bit of a security risk to broadcast the apiKey to the local network, so maybe it is better to keep adding the apiKey to the discovery plugin as an explicit step.

NOTE: In parallel I am working on a printer connection for Cura that will enable Cura to auto-discover and print directly to OctoPrint - Slic3r can already do this (minus the auto-discovery).