### PR TITLE
Include files required by setup.py in sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ recursive-include src/octoprint/static *
 recursive-include src/octoprint/templates *
 include versioneer.py
 include src/octoprint/_version.py
+include README.md
+include requirements.txt


### PR DESCRIPTION
`README.md` and `requirements.txt` are both used by `setup.py`, so they need to be included in `MANIFEST.in` so they are rolled into tarballs by the `sdist` command.