### PR TITLE
Fix inability to set printer profile extruder feedrate from settings UI

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/printerprofiles.js
+++ b/src/octoprint/static/js/app/viewmodels/printerprofiles.js
@@ -368,6 +368,10 @@ $(function() {
                     z: {
                         speed: parseInt(self.editorAxisZSpeed()),
                         inverted: self.editorAxisZInverted()
+                    },
+                    e: {
+                        speed: parseInt(self.editorAxisESpeed()),
+                        inverted: self.editorAxisEInverted()
                     }
                 }
             };


### PR DESCRIPTION
In Settings -> Printer Profiles -> Edit Pencil Icon, if a user changes the Extruder axis feedrate, the setting isn't saved. This is because the editorData JSON object doesn't include the E axis when the data is PATCH posted.

This code patch patches the PATCH to patch in the E... patch and allow a handsome user such as myself to modify a printer's extruder feedrate which is otherwise completely impossible and makes everyone feel hopeless and in need of cookies. I LOVE COOKIES
