### PR TITLE
Fix: Settings modal did not display properly on iPad and other browsers ...

### DIFF
--- a/src/octoprint/static/less/octoprint.less
+++ b/src/octoprint/static/less/octoprint.less
@@ -905,3 +905,12 @@ textarea.block {
     }
   }
 }
+
+.modal-body {
+  .span4 {
+    width: 25%;
+  }
+  .span8 {
+    width: 65%;
+  }
+}


### PR DESCRIPTION
...under 1200px wide

The float in the modal over lay on browsers that are under 1200px wide cause the content that was supposed to be on the right hand side to flow below it.

I've changed the width of the menu and right content to use percentages, this might not be desired but it was the only way I could think to fix it. I'm far from a CSS expert so there might be a better way.