### PR TITLE
update FileSelected event to be more consistent with other events

### DIFF
--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -168,7 +168,8 @@ FileSelected
 
    Payload:
 
-     * ``file``: the file's name
+     * ``file``: the full path to the file
+     * ``filename``: the file's name
      * ``origin``: the origin of the file, either ``local`` or ``sdcard``
 
 FileDeselected

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -115,7 +115,7 @@ class MachineCom(object):
 	STATE_ERROR = 9
 	STATE_CLOSED_WITH_ERROR = 10
 	STATE_TRANSFERING_FILE = 11
-	
+
 	def __init__(self, port = None, baudrate=None, callbackObject=None, printerProfileManager=None):
 		self._logger = logging.getLogger(__name__)
 		self._serialLogger = logging.getLogger("SERIAL")
@@ -255,7 +255,7 @@ class MachineCom(object):
 
 	def getState(self):
 		return self._state
-	
+
 	def getStateString(self):
 		if self._state == self.STATE_NONE:
 			return "Offline"
@@ -287,19 +287,19 @@ class MachineCom(object):
 		if self._state == self.STATE_TRANSFERING_FILE:
 			return "Transfering file to SD"
 		return "?%d?" % (self._state)
-	
+
 	def getErrorString(self):
 		return self._errorValue
-	
+
 	def isClosedOrError(self):
 		return self._state == self.STATE_ERROR or self._state == self.STATE_CLOSED_WITH_ERROR or self._state == self.STATE_CLOSED
 
 	def isError(self):
 		return self._state == self.STATE_ERROR or self._state == self.STATE_CLOSED_WITH_ERROR
-	
+
 	def isOperational(self):
 		return self._state == self.STATE_OPERATIONAL or self._state == self.STATE_PRINTING or self._state == self.STATE_PAUSED or self._state == self.STATE_TRANSFERING_FILE
-	
+
 	def isPrinting(self):
 		return self._state == self.STATE_PRINTING
 
@@ -349,7 +349,7 @@ class MachineCom(object):
 
 	def getTemp(self):
 		return self._temp
-	
+
 	def getBedTemp(self):
 		return self._bedTemp
 
@@ -552,6 +552,7 @@ class MachineCom(object):
 			self._currentFile = PrintingGcodeFileInformation(filename, offsets_callback=self.getOffsets, current_tool_callback=self.getCurrentTool)
 			eventManager().fire(Events.FILE_SELECTED, {
 				"file": self._currentFile.getFilename(),
+				"filename": os.path.basename(self._currentFile.getFilename()),
 				"origin": self._currentFile.getFileLocation()
 			})
 			self._callback.on_comm_file_selected(filename, self._currentFile.getFilesize(), False)


### PR DESCRIPTION
This PR makes the payload of the `FileSelected` event the same as the start, cancel, and pause events by adding a `filename` field.