### PR TITLE
Allow user to specify arbitrary metadata when uploading a file. (Redux)

### DIFF
--- a/docs/api/fileops.rst
+++ b/docs/api/fileops.rst
@@ -219,6 +219,9 @@ Upload file
                     to ``false``.
    :form print:     Whether to start printing the file directly after upload (``true``) or not (``false``). If set, `select`
                     is implicitely ``true`` as well. Optional, defaults to ``false``.
+   :form userdata:  [Optional] An optional string that if specified will be saved along with the file as metadata.
+   :form userjson:  [Optional] An optional string that if specified will be intepreted as json and then saved along with
+                    the file as metadata.
    :statuscode 201: No error
    :statuscode 400: If no `file` is included in the request, or the request is otherwise invalid.
    :statuscode 404: If `location` is neither ``local`` nor ``sdcard`` or trying to upload to SD card and SD card support

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -214,6 +214,13 @@ def uploadGcodeFile(target):
 		filename = fileProcessingFinished(added_file, fileManager.path_on_disk(FileDestinations.LOCAL, added_file), target)
 		done = True
 
+    # Store any additional user data the caller may have passed.
+	if 'userjson' in request.values:
+		import json
+		fileManager.set_additional_metadata(FileDestinations.LOCAL, added_file, 'userjson', json.loads(request.values['userjson']))
+	if 'userdata' in request.values:
+		fileManager.set_additional_metadata(FileDestinations.LOCAL, added_file, 'userdata', request.values['userdata'])
+
 	sdFilename = None
 	if isinstance(filename, tuple):
 		filename, sdFilename = filename


### PR DESCRIPTION
(_Reopened from a new branch as specified in the docs. Original details:_)

This PR allows the user to specify arbitrary metadata when uploading a file through the API endpoint.

With these changes `POST`ing to `/files/<target>` will check to see if either `userdata` or `userjson` was included in the form data. If `userdata` was included then it is stored with the file by calling the `FileManager.set_additional_metadata()` method with the string "userdata" as the key and the supplied string as the value. If `userjson` was included in the request then the string is decoded as a JSON object before storing it under the key "userjson". Both parameters are optional.

This PR is usefull for users who want to associate additional data with a file, as any additional metadata stored in this manner is returned when `GET`ting the file's properties.