### PR TITLE
Fix server error 500 when user is logged out

### DIFF
--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -58,6 +58,8 @@ def passive_login():
 			logger = logging.getLogger(__name__)
 			logger.exception("Could not autologin user %s for networks %r" % (autologinAs, localNetworks))
 
+	return ("", 204)
+
 
 #~~ cache decorator for cacheable views
 


### PR DESCRIPTION
f98ebaaf moved the passive_logon code to a new function from
api/__init__.py to util/flask.py.  Before that move any fallthrough
would hit return NO_CONTENT, but now it returns nothing which makes
flask complain.