### PR TITLE
Add support for high-DPI screens to gcode renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
 * Added support for rectangular printer beds with the origin in the center ([#682](https://github.com/foosel/OctoPrint/issues/682) 
   and [#852](https://github.com/foosel/OctoPrint/pull/852)). Printer profiles now contain a new settings ``volume.origin``
   which can either be ``lowerleft`` or ``center``. For circular beds only ``center`` is supported.
+* High-DPI support for the GCode viewer
 
 ### Bug Fixes
 

--- a/src/octoprint/static/gcodeviewer/js/renderer.js
+++ b/src/octoprint/static/gcodeviewer/js/renderer.js
@@ -14,6 +14,7 @@ GCODE.renderer = (function(){
     var gridStep=10;
     var ctxHeight, ctxWidth;
     var prevX=0, prevY=0;
+    var pixelRatio = window.devicePixelRatio || 1;
 
     var layerNumStore, progressStore={from: 0, to: -1};
     var lastX, lastY;
@@ -32,9 +33,9 @@ GCODE.renderer = (function(){
 
         showMoves: true,
         showRetracts: true,
-        extrusionWidth: 1,
+        extrusionWidth: 1 * pixelRatio,
         // #000000", "#45c7ba",  "#a9533a", "#ff44cc", "#dd1177", "#eeee22", "#ffbb55", "#ff5511", "#777788"
-        sizeRetractSpot: 2,
+        sizeRetractSpot: 2 * pixelRatio,
         modelCenter: {x: 0, y: 0},
         differentiateColors: true,
         showNextLayer: false,
@@ -136,6 +137,10 @@ GCODE.renderer = (function(){
         canvas = jqueryCanvas[0];
 
         ctx = canvas.getContext('2d');
+        canvas.style.height = canvas.height + "px";
+        canvas.style.width = canvas.width + "px";
+        canvas.height = canvas.height * pixelRatio;
+        canvas.width = canvas.width * pixelRatio;
         ctxHeight = canvas.height;
         ctxWidth = canvas.width;
         lastX = ctxWidth/2;
@@ -149,8 +154,8 @@ GCODE.renderer = (function(){
             document.body.style.mozUserSelect = document.body.style.webkitUserSelect = document.body.style.userSelect = 'none';
 
             // remember starting point of dragging gesture
-            lastX = event.offsetX || (event.pageX - canvas.offsetLeft);
-            lastY = event.offsetY || (event.pageY - canvas.offsetTop);
+            lastX = (event.offsetX || (event.pageX - canvas.offsetLeft)) * pixelRatio;
+            lastY = (event.offsetY || (event.pageY - canvas.offsetTop)) * pixelRatio;
             dragStart = ctx.transformedPoint(lastX, lastY);
 
             // not yet dragged anything
@@ -159,8 +164,8 @@ GCODE.renderer = (function(){
 
         canvas.addEventListener('mousemove', function(event){
             // save current mouse coordinates
-            lastX = event.offsetX || (event.pageX - canvas.offsetLeft);
-            lastY = event.offsetY || (event.pageY - canvas.offsetTop);
+            lastX = (event.offsetX || (event.pageX - canvas.offsetLeft)) * pixelRatio;
+            lastY = (event.offsetY || (event.pageY - canvas.offsetTop)) * pixelRatio;
 
             // mouse movement => dragged
             dragged = true;


### PR DESCRIPTION
Fixes #837.

I've tested it in Safari and Chrome on OS X, would be cool if somebody with access to more browsers could have a look.

Old:

![screenshot 2015-04-18 12 05 42](https://cloud.githubusercontent.com/assets/918034/7215025/c295cd4e-e5c4-11e4-9a93-90d8a718b024.png)

New:

![screenshot 2015-04-18 12 05 47](https://cloud.githubusercontent.com/assets/918034/7215026/c2b82240-e5c4-11e4-81b8-dbe64d57de64.png)
