### PR TITLE
Use BadRequest instead of JSONBadRequest.

### DIFF
--- a/src/octoprint/server/api/printer.py
+++ b/src/octoprint/server/api/printer.py
@@ -6,7 +6,7 @@ __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 from flask import request, jsonify, make_response, Response
-from flask.exceptions import JSONBadRequest
+from flask.exceptions import BadRequest
 import re
 
 from octoprint.settings import settings, valid_boolean_trues
@@ -331,7 +331,7 @@ def printerCommand():
 
 	try:
 		data = request.json
-	except JSONBadRequest:
+	except BadRequest:
 		return make_response("Malformed JSON body in request", 400)
 
 	if "command" in data and "commands" in data:

--- a/src/octoprint/server/api/printer_profiles.py
+++ b/src/octoprint/server/api/printer_profiles.py
@@ -9,7 +9,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 import copy
 
 from flask import jsonify, make_response, request, url_for
-from flask.exceptions import JSONBadRequest
+from flask.exceptions import BadRequest
 
 from octoprint.server.api import api, NO_CONTENT
 from octoprint.server.util.flask import restricted_access
@@ -32,7 +32,7 @@ def printerProfilesAdd():
 
 	try:
 		json_data = request.json
-	except JSONBadRequest:
+	except BadRequest:
 		return make_response("Malformed JSON body in request", 400)
 
 	if not "profile" in json_data:
@@ -91,7 +91,7 @@ def printerProfilesUpdate(identifier):
 
 	try:
 		json_data = request.json
-	except JSONBadRequest:
+	except BadRequest:
 		return make_response("Malformed JSON body in request", 400)
 
 	if not "profile" in json_data:

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -8,7 +8,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 import logging
 
 from flask import request, jsonify, make_response
-from flask.exceptions import JSONBadRequest
+from flask.exceptions import BadRequest
 
 from octoprint.events import eventManager, Events
 from octoprint.settings import settings
@@ -138,7 +138,7 @@ def setSettings():
 
 	try:
 		data = request.json
-	except JSONBadRequest:
+	except BadRequest:
 		return make_response("Malformed JSON body in request", 400)
 	s = settings()
 

--- a/src/octoprint/server/api/slicing.py
+++ b/src/octoprint/server/api/slicing.py
@@ -6,7 +6,7 @@ __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 from flask import request, jsonify, make_response, url_for
-from flask.exceptions import JSONBadRequest
+from flask.exceptions import BadRequest
 
 from octoprint.server import slicingManager
 from octoprint.server.util.flask import restricted_access
@@ -75,7 +75,7 @@ def slicingAddSlicerProfile(slicer, name):
 
 	try:
 		json_data = request.json
-	except JSONBadRequest:
+	except BadRequest:
 		return make_response("Malformed JSON body in request", 400)
 
 	data = dict()
@@ -114,7 +114,7 @@ def slicingPatchSlicerProfile(slicer, name):
 
 	try:
 		json_data = request.json
-	except JSONBadRequest:
+	except BadRequest:
 		return make_response("Malformed JSON body in request", 400)
 
 	data = dict()

--- a/src/octoprint/server/api/users.py
+++ b/src/octoprint/server/api/users.py
@@ -6,7 +6,7 @@ __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 from flask import request, jsonify, abort, make_response
-from flask.exceptions import JSONBadRequest
+from flask.exceptions import BadRequest
 from flask.ext.login import current_user
 
 import octoprint.users as users
@@ -41,7 +41,7 @@ def addUser():
 
 	try:
 		data = request.json
-	except JSONBadRequest:
+	except BadRequest:
 		return make_response("Malformed JSON body in request", 400)
 
 	name = data["name"]
@@ -89,7 +89,7 @@ def updateUser(username):
 
 		try:
 			data = request.json
-		except JSONBadRequest:
+		except BadRequest:
 			return make_response("Malformed JSON body in request", 400)
 
 		# change roles
@@ -132,7 +132,7 @@ def changePasswordForUser(username):
 
 		try:
 			data = request.json
-		except JSONBadRequest:
+		except BadRequest:
 			return make_response("Malformed JSON body in request", 400)
 
 		if not "password" in data.keys() or not data["password"]:
@@ -173,7 +173,7 @@ def changeSettingsForUser(username):
 
 	try:
 		data = request.json
-	except JSONBadRequest:
+	except BadRequest:
 		return make_response("Malformed JSON body in request", 400)
 
 	try:


### PR DESCRIPTION
This PR improves (or possibly solves) Flask 0.10 compatibility issues.

JSONBadRequest is removed in Flask version 0.10. BadRequest is backwards
compatible with Flask 0.9.

I tried to add tests, but the API code where these Exception classes are used is dependent on config code that makes it hard to isolate for testing purposes.