### PR TITLE
flask 0.10 fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import versioneer
 
 # Requirements for our application
 INSTALL_REQUIRES = [
-	"flask==0.9",
+	"flask>=0.9,<0.11",
 	"werkzeug==0.8.3",
 	"tornado==4.0.1",
 	"sockjs-tornado>=1.0.0",

--- a/src/octoprint/server/api/printer.py
+++ b/src/octoprint/server/api/printer.py
@@ -6,7 +6,7 @@ __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 from flask import request, jsonify, make_response, Response
-from flask.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest
 import re
 
 from octoprint.settings import settings, valid_boolean_trues

--- a/src/octoprint/server/api/printer_profiles.py
+++ b/src/octoprint/server/api/printer_profiles.py
@@ -9,7 +9,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 import copy
 
 from flask import jsonify, make_response, request, url_for
-from flask.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest
 
 from octoprint.server.api import api, NO_CONTENT
 from octoprint.server.util.flask import restricted_access

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -8,7 +8,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 import logging
 
 from flask import request, jsonify, make_response
-from flask.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest
 
 from octoprint.events import eventManager, Events
 from octoprint.settings import settings

--- a/src/octoprint/server/api/slicing.py
+++ b/src/octoprint/server/api/slicing.py
@@ -6,7 +6,7 @@ __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 from flask import request, jsonify, make_response, url_for
-from flask.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest
 
 from octoprint.server import slicingManager
 from octoprint.server.util.flask import restricted_access

--- a/src/octoprint/server/api/users.py
+++ b/src/octoprint/server/api/users.py
@@ -6,7 +6,7 @@ __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 from flask import request, jsonify, abort, make_response
-from flask.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest
 from flask.ext.login import current_user
 
 import octoprint.users as users


### PR DESCRIPTION
Forgot to actually allow flask 0.10 in setup.py. When I did, I saw that all of `flask.exceptions` is gone in that version. Use BadRequest from werkzeug instead.