### PR TITLE
onSettingsShown/Hidden call only on parent dialog shown/hidden

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -143,19 +143,23 @@ $(function() {
         };
 
         self.onAllBound = function(allViewModels) {
-            self.settingsDialog.on('show', function() {
-                _.each(allViewModels, function(viewModel) {
-                    if (viewModel.hasOwnProperty("onSettingsShown")) {
-                        viewModel.onSettingsShown();
-                    }
-                });
+            self.settingsDialog.on('show', function(event) {
+                if (event.target.id == "settings_dialog") {
+                    _.each(allViewModels, function(viewModel) {
+                        if (viewModel.hasOwnProperty("onSettingsShown")) {
+                            viewModel.onSettingsShown();
+                        }
+                    });
+                }
             });
             self.settingsDialog.on('hidden', function() {
-                _.each(allViewModels, function(viewModel) {
-                    if (viewModel.hasOwnProperty("onSettingsHidden")) {
-                        viewModel.onSettingsHidden();
-                    }
-                });
+                if (event.target.id == "settings_dialog") {
+                    _.each(allViewModels, function(viewModel) {
+                        if (viewModel.hasOwnProperty("onSettingsHidden")) {
+                            viewModel.onSettingsHidden();
+                        }
+                    });
+                }
             });
             self.settingsDialog.on('beforeSave', function () {
                 _.each(allViewModels, function (viewModel) {


### PR DESCRIPTION
jQuery bubbles all children show/hide events up to the parent so the
event gets called whenever a settings pane is chosen by the user.
Intent of the viewmodel callback was just on first show and final
dismiss.