### PR TITLE
Fix for File not able to delete after Serial Error

### DIFF
--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -356,7 +356,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 		self._setCurrentZ(None)
 
 	def unselect_file(self):
-		if self._comm is not None and (self._comm.isBusy() or self._comm.isStreaming()):
+		if self._comm is None or (self._comm.isBusy() or self._comm.isStreaming()):
 			return
 
 		self._comm.unselectFile()

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -236,7 +236,7 @@ class MachineCom(object):
 		if self._state == newState:
 			return
 
-		if self._currentFile is not None and (newState == self.STATE_ERROR or newState == self.STATE_CLOSED_WITH_ERROR):
+		if self._currentFile is not None and (newState == self.STATE_CLOSED or newState == self.STATE_ERROR or newState == self.STATE_CLOSED_WITH_ERROR):
 			self._currentFile.close()
 
 		if newState == self.STATE_CLOSED or newState == self.STATE_CLOSED_WITH_ERROR:

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -236,10 +236,10 @@ class MachineCom(object):
 		if self._state == newState:
 			return
 
-		if newState == self.STATE_CLOSED or newState == self.STATE_CLOSED_WITH_ERROR:
-			if self._currentFile is not None:
-				self._currentFile.close()
+		if self._currentFile is not None and (newState == self.STATE_ERROR or newState == self.STATE_CLOSED_WITH_ERROR):
+			self._currentFile.close()
 
+		if newState == self.STATE_CLOSED or newState == self.STATE_CLOSED_WITH_ERROR:
 			if settings().get(["feature", "sdSupport"]):
 				self._sdFileList = False
 				self._sdFiles = []


### PR DESCRIPTION
As said in IRC, if you print and a Serial error occurs you were not able to delete the file.

This small fix takes care of it, every PrintingGcodeFileInformation subscribes to the FILE_DESELECTED event, and closes the _handle if still open.