### PR TITLE
Stop sockjs from multiplying on reconnect

### DIFF
--- a/src/octoprint/static/js/app/dataupdater.js
+++ b/src/octoprint/static/js/app/dataupdater.js
@@ -22,6 +22,7 @@ function DataUpdater(allViewModels) {
     };
 
     self.reconnect = function() {
+        self._socket.close();
         delete self._socket;
         self.connect();
     };
@@ -31,7 +32,11 @@ function DataUpdater(allViewModels) {
         self._autoReconnectTrial = 0;
     };
 
-    self._onclose = function() {
+    self._onclose = function(e) {
+        if (e.code == 1000) {
+            // it was us calling close
+            return;
+        }
         if (self._autoReconnectTrial >= self._autoReconnectDialogIndex) {
             // Only consider it a real disconnect if the trial number has exceeded our threshold.
 

--- a/src/octoprint/static/js/app/dataupdater.js
+++ b/src/octoprint/static/js/app/dataupdater.js
@@ -33,8 +33,7 @@ function DataUpdater(allViewModels) {
     };
 
     self._onclose = function(e) {
-        if (e.code == 1000) {
-            // it was us calling close
+        if (e.code == SOCKJS_CLOSE_NORMAL) {
             return;
         }
         if (self._autoReconnectTrial >= self._autoReconnectDialogIndex) {

--- a/src/octoprint/templates/initscript.jinja2
+++ b/src/octoprint/templates/initscript.jinja2
@@ -20,6 +20,8 @@
 
     var SOCKJS_URI = "{{ url_for('index') }}" + "sockjs";
     var SOCKJS_DEBUG = CONFIG_DEBUG;
+    // sockjs should define CLOSE_NORMAL for us, but they don't (from ws spec)
+    var SOCKJS_CLOSE_NORMAL = 1000
 
     var UI_API_KEY = "{{ uiApiKey }}";
     var VERSION = "{{ version }}";


### PR DESCRIPTION
Have you ever noticed when developing that every time you stop and start
the server, the terminal window gets an extra duplicate line for every
reconnect attempt?  Well, it's because (I think) "delete" in javascript
just removes the indicated name from the namespace, it doesn't actually
free up an object. Those zombie objects are still there and wake up (for
some transports) on reconnect. Might be different in SockJS v1 or later.

Anyway, this fixes it for me in Chrome.