### PR TITLE
[WIP] Initial SDCardFileStorage implementation of StorageInterface

### DIFF
--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -299,7 +299,7 @@ class FileManager(object):
 			result[dst] = self._storage_managers[dst].list_files(path=path, filter=filter, recursive=recursive)
 		return result
 
-	def add_file(self, destination, path, file_object, links=None, allow_overwrite=False, printer_profile=None, analysis=None):
+	def add_file(self, destination, path, file_object, links=None, allow_overwrite=False, printer_profile=None, analysis=None, callback=None):
 		if printer_profile is None:
 			printer_profile = self._printer_profile_manager.get_current_or_default()
 
@@ -307,7 +307,7 @@ class FileManager(object):
 			hook_file_object = hook(path, file_object, links=links, printer_profile=printer_profile, allow_overwrite=allow_overwrite)
 			if hook_file_object is not None:
 				file_object = hook_file_object
-		file_path = self._storage(destination).add_file(path, file_object, links=links, printer_profile=printer_profile, allow_overwrite=allow_overwrite)
+		file_path = self._storage(destination).add_file(path, file_object, links=links, printer_profile=printer_profile, allow_overwrite=allow_overwrite, callback=callback)
 		absolute_path = self._storage(destination).path_on_disk(file_path)
 
 		if analysis is None:

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -590,6 +590,7 @@ class Server():
 		storage_managers[octoprint.filemanager.FileDestinations.LOCAL] = octoprint.filemanager.storage.LocalFileStorage(settings().getBaseFolder("uploads"))
 		fileManager = octoprint.filemanager.FileManager(analysisQueue, slicingManager, printerProfileManager, initial_storage_managers=storage_managers)
 		printer = Printer(fileManager, analysisQueue, printerProfileManager)
+		fileManager.add_storage(octoprint.filemanager.FileDestinations.SDCARD, octoprint.filemanager.storage.SDCardFileStorage(printer, fileManager))
 		appSessionManager = util.flask.AppSessionManager()
 		pluginLifecycleManager = LifecycleManager(pluginManager)
 

--- a/tests/filemanager/test_filemanager.py
+++ b/tests/filemanager/test_filemanager.py
@@ -62,7 +62,7 @@ class FileManagerTest(unittest.TestCase):
 		file_path = self.file_manager.add_file(octoprint.filemanager.FileDestinations.LOCAL, "test.file", wrapper)
 
 		self.assertEquals(("", "test.file"), file_path)
-		self.local_storage.add_file.assert_called_once_with("test.file", wrapper, printer_profile=test_profile, allow_overwrite=False, links=None)
+		self.local_storage.add_file.assert_called_once_with("test.file", wrapper, printer_profile=test_profile, allow_overwrite=False, links=None, callback=None)
 		self.fire_event.assert_called_once_with(octoprint.filemanager.Events.UPDATED_FILES, dict(type="printables"))
 
 	def test_remove_file(self):
@@ -150,7 +150,7 @@ class FileManagerTest(unittest.TestCase):
 		self.local_storage.split_path.side_effect = split_path
 
 		# mock add_file method on local storage
-		def add_file(path, file_obj, printer_profile=None, links=None, allow_overwrite=False):
+		def add_file(path, file_obj, printer_profile=None, links=None, allow_overwrite=False, callback=None):
 			file_obj.save("prefix/" + path)
 			return "", path
 		self.local_storage.add_file.side_effect = add_file
@@ -184,7 +184,7 @@ class FileManagerTest(unittest.TestCase):
 
 		# assert that model links were added
 		expected_links = [("model", dict(name="source.file"))]
-		self.local_storage.add_file.assert_called_once_with("dest.file", mock.ANY, printer_profile=expected_printer_profile, allow_overwrite=True, links=expected_links)
+		self.local_storage.add_file.assert_called_once_with("dest.file", mock.ANY, printer_profile=expected_printer_profile, allow_overwrite=True, links=expected_links, callback=None)
 
 		# assert that the generated gcode was manipulated as required
 		expected_open_calls = [mock.call("prefix/dest.file", "wb")]


### PR DESCRIPTION
This isn't really ready for a pull. I just created it to continue the conversation on issue #851 with some code.

This initial change is intended to create a StorageInterface
implementation for the sdcard. At this point it doesn't attempt to
change any functionality outside of that already supported for SD cards,
just change the code flow through the fileManager.

Is this the direction you were talking about in issue #851?  What way
would you prefer to handle the unsupported (yet) functionality.
NotImplemented as here or with io.Unsupported as specified for some?

Also, note how I've got this calling back through the fileManager for
LOCAL storage on upload. Should it work this way or should it be a
subclass of LocalFileStorage or some other structure? To do some of the
other StorageInterface, more of it will want to rely on the
LocalFileStorage, I think.

Perhaps the SDCardFileStorage should create its own LocalFileStorage at
a different base path as an SDCard shadow to do some of the metadata,
etc. As an actual mirror rather than just for upload, it would be more
reliable for some of the metadata, analysis purposes. It could also be
enhanced if firmwares were willing to give us a hash for comparison (to
avoid streaming the file to check).
