### PR TITLE
Only eat two characters when the error indicator is '!!'

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -1287,7 +1287,7 @@ class MachineCom(object):
 				self._lastCommError = line[6:] if line.startswith("Error:") else line[2:]
 				pass
 			elif not self.isError():
-				self._errorValue = line[6:]
+				self._errorValue = line[6:] if line.startswith("Error:") else line[2:]
 				self._changeState(self.STATE_ERROR)
 				eventManager().fire(Events.ERROR, {"error": self.getErrorString()})
 		return line


### PR DESCRIPTION
Same as 3 lines earlier now that I do the PR.  Would you rather I did:
error = line[6:] if line.startswith("Error:") else line[2:]
before the if and then use the local in each case?