### PR TITLE
scripts: init and default files now specify a process priority.

### DIFF
--- a/scripts/octoprint.default
+++ b/scripts/octoprint.default
@@ -15,5 +15,9 @@ DAEMON_ARGS="--port=$PORT"
 # Umask of files octoprint generates, Change this to 000 if running octoprint as its own, separate user
 UMASK=022
 
+# Process priority, 0 here will result in a priority 20 process.
+# -2 ensures Octoprint has a slight priority over user processes.
+NICELEVEL=-2
+
 # Should we run at startup?
 START=yes

--- a/scripts/octoprint.init
+++ b/scripts/octoprint.init
@@ -73,7 +73,8 @@ do_start()
 
    if [ $RETVAL != 0 ]; then
        start-stop-daemon --start --background --quiet --pidfile $PIDFILE --make-pidfile \
-       --exec $DAEMON --chuid $OCTOPRINT_USER --user $OCTOPRINT_USER --umask $UMASK -- $DAEMON_ARGS
+       --exec $DAEMON --chuid $OCTOPRINT_USER --user $OCTOPRINT_USER --umask $UMASK --nicelevel=$NICELEVEL \
+       -- $DAEMON_ARGS
        RETVAL="$?"
    fi
 }


### PR DESCRIPTION
default to priority of 18 (nicelevel of -2).

///

It's nice to have the Octoprint process priority a little higher than everything else. This makes that happen.
