### PR TITLE
Fixed a missing self.buffer()

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/terminal.js
+++ b/src/octoprint/static/js/app/viewmodels/terminal.js
@@ -86,7 +86,7 @@ $(function() {
         self._processCurrentLogData = function(data) {
             self.log(self.log().concat(_.map(data, function(line) { return self._toInternalFormat(line) })));
             if (self.autoscrollEnabled()) {
-                self.log(self.log.slice(-300));
+                self.log(self.log.slice(-self.buffer()));
             }
         };
 


### PR DESCRIPTION
Just spotted a missing self.buffer() while "reusing" the terminal code