### PR TITLE
Fix sorting of templates

### DIFF
--- a/src/octoprint/server/views.py
+++ b/src/octoprint/server/views.py
@@ -230,8 +230,30 @@ def index():
 		# finally add anything that's not included in our order yet
 		sorted_missing = list(missing_in_order)
 		if template_sorting[t]["key"] is not None:
-			# anything but navbar and generic components get sorted by their name
-			sorted_missing = sorted(missing_in_order, key=lambda x: templates[t]["entries"][x][1][template_sorting[t]["key"]])
+			# default extractor: works with entries that are dicts and entries that are 2-tuples with the
+			# entry data at index 1
+			extractor = \
+				lambda x, k: \
+					x[k] if isinstance(x, dict) and k in x \
+				else \
+					x[1][k] if isinstance(x, tuple) and len(x) > 1 and isinstance(x[1], dict) and k in x[1] \
+				else\
+					None
+
+			# if template type provides custom extractor, make sure its exceptions are handled
+			if "key_extractor" in template_sorting[t] and callable(template_sorting[t]["key_extractor"]):
+				def create_safe_extractor(extractor):
+					def f(x, k):
+						try:
+							return extractor(x, k)
+						except:
+							_logger.exception("Error while extracting sorting keys for template {}".format(t))
+							return None
+					return f
+				extractor = create_safe_extractor(template_sorting[t]["key_extractor"])
+
+			sort_key = template_sorting[t]["key"]
+			sorted_missing = sorted(missing_in_order, key=lambda x: extractor(templates[t]["entries"][x], sort_key))
 
 		if template_sorting[t]["add"] == "prepend":
 			templates[t]["order"] = sorted_missing + templates[t]["order"]

--- a/src/octoprint/server/views.py
+++ b/src/octoprint/server/views.py
@@ -231,8 +231,7 @@ def index():
 		sorted_missing = list(missing_in_order)
 		if template_sorting[t]["key"] is not None:
 			# anything but navbar and generic components get sorted by their name
-			if template_sorting[t]["key"] == "name":
-				sorted_missing = sorted(missing_in_order, key=lambda x: templates[t]["entries"][x][0])
+			sorted_missing = sorted(missing_in_order, key=lambda x: templates[t]["entries"][x][1][template_sorting[t]["key"]])
 
 		if template_sorting[t]["add"] == "prepend":
 			templates[t]["order"] = sorted_missing + templates[t]["order"]


### PR DESCRIPTION
I noticed that no sorting is happening no matter what "key" I gave for sorting.
So I investigated the situation and found that there was a hard coded check for key == name, 
but nothing for key != name

