### PR TITLE
[WIP] Append environment information to the Bug Report link

### DIFF
--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -600,6 +600,7 @@ def collect_plugin_assets(enable_gcodeviewer=True, enable_timelapse=True, prefer
 		'js/app/viewmodels/control.js',
 		'js/app/viewmodels/firstrun.js',
 		'js/app/viewmodels/files.js',
+		'js/app/viewmodels/footer.js',
 		'js/app/viewmodels/loginstate.js',
 		'js/app/viewmodels/navigation.js',
 		'js/app/viewmodels/printerstate.js',

--- a/src/octoprint/static/js/app/viewmodels/footer.js
+++ b/src/octoprint/static/js/app/viewmodels/footer.js
@@ -1,0 +1,27 @@
+$(function() {
+    function FooterViewModel(parameters) {
+        var self = this;
+
+        self.appendEnvironmentInfo = function(data, event){
+
+            // Build bug reporting URL
+            var environmentInfo = {
+                src : "ui",
+                version : $(".version").text(),
+                userAgent : navigator ? navigator.appVersion : "Unknown"
+            }
+
+            var target = event.target;
+            var url = target.href + '?' + $.param(environmentInfo);
+
+            // Redirect to the url
+            window.location.href = url;
+        }
+    }
+
+    OCTOPRINT_VIEWMODELS.push([
+        FooterViewModel,
+        [],
+        ".footer"
+    ]);
+});

--- a/src/octoprint/templates/index.jinja2
+++ b/src/octoprint/templates/index.jinja2
@@ -118,7 +118,7 @@
                         <li><a href="http://octoprint.org"><i class="icon-home"></i> {{ _('Homepage') }}</a></li>
                         <li><a href="https://github.com/foosel/OctoPrint/"><i class="icon-github"></i> {{ _('Sourcecode') }}</a></li>
                         <li><a href="http://docs.octoprint.org"><i class="icon-book"></i> {{ _('Documentation') }}</a></li>
-                        <li><a href="https://github.com/foosel/OctoPrint/issues"><i class="icon-flag"></i> {{ _('Bugs and Requests') }}</a></li>
+                        <li><a href="https://github.com/foosel/OctoPrint/issues" data-bind="click: appendEnvironmentInfo"><i class="icon-flag"></i> {{ _('Bugs and Requests') }}</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Initial implementation of including information in the bug report link. Not currently useful in it's present form, but could be used as a base for automating the inclusion of some of the data required for a bug report.

May need to consider privacy concerns (although there's no personal information included in the data, people may not like information about their system being sent to a third party)

Full implementation may need an additional page or two to be hosted at Octoprint.org as well as a couple of python scripts hosted on the OctoPrint instance itself.

Thought I'd post this as a mini proof-of-concept.

My thoughts on the process would be something along the lines of...
1. Link takes you to an Octoprint.org/.... page which strips off the information and stores it in a cookie which is valid for, say, an hour.
2. Octoprint page then automatically redirects user to bug reporting guide
3. Change link in bug reporting guide to point to Octoprint.org page. On this page are buttons that allow the user to automatically retrieve and upload their logs to pastebin or a gist. Request to user's host could be made via JSONP
4. Once user has uploaded logs (if desired) submit button takes them to GitHub new Issue page with  template partially filled in with Version, Browser / OS, urls to logs etc.

I'm happy to look into the implementation side on the host if you think this is a viable solution.

Comments welcome!

Richard
