### PR TITLE
MacOS: fix path quirk in filemanager unit tests.

### DIFF
--- a/tests/filemanager/test_localstorage.py
+++ b/tests/filemanager/test_localstorage.py
@@ -8,6 +8,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 import unittest
 import os
 import mock
+import os.path
 
 from ddt import ddt, unpack, data
 
@@ -41,7 +42,7 @@ class LocalStorageTest(unittest.TestCase):
 
 	def setUp(self):
 		import tempfile
-		self.basefolder = tempfile.mkdtemp()
+		self.basefolder = os.path.realpath(os.path.abspath(tempfile.mkdtemp()))
 		self.storage = octoprint.filemanager.storage.LocalFileStorage(self.basefolder)
 
 		# mock file manager module


### PR DESCRIPTION
On MacOS, `tempfile.mkdtemp()` doesn't necessarily return a canonical
path (it uses `/private/var` instead of `/var`, but they are the same
thing). Since the `filemanager.storage` module canonicalizes paths,
tests were erroneously failing due to prefix match failures.