### PR TITLE
Fix positioning of ContextMenu

### DIFF
--- a/src/octoprint/static/js/app/main.js
+++ b/src/octoprint/static/js/app/main.js
@@ -321,7 +321,7 @@ $(function() {
                         .data("contextParent", $(this))
                         .show()
                         .css({
-                            position: "absolute",
+                            position: "fixed",
                             left: getMenuPosition(e.clientX, 'width', 'scrollLeft'),
                             top: getMenuPosition(e.clientY, 'height', 'scrollTop'),
                             "z-index": 9999


### PR DESCRIPTION
For some unknown reason suddenly the ContextMenu was far of the mouse position, this fixes it.