### PR TITLE
Fix Repetier Resend Request v2

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -1375,7 +1375,7 @@ class MachineCom(object):
 			if self._regex_minMaxError.match(line):
 				line = line.rstrip() + self._readline()
 
-			if 'line number' in line.lower() or 'checksum' in line.lower() or 'expected line' in line.lower():
+			if 'line number' in line.lower() or 'checksum' in line.lower() or 'format error' in line.lower() or 'expected line' in line.lower():
 				#Skip the communication errors, as those get corrected.
 				self._lastCommError = line[6:] if line.startswith("Error:") else line[2:]
 				pass


### PR DESCRIPTION
New PR for #1015

This should now prevent OctoPrint from closing connection on a recoverable Format Error