### PR TITLE
versioneer lookup: add support for detached checkouts

### DIFF
--- a/.versioneer-lookup
+++ b/.versioneer-lookup
@@ -15,5 +15,8 @@ master
 maintenance 1.2.5 9a6099ffc2982455d631c9d68a3273d9eb55885c
 fix/.* 1.2.5 9a6099ffc2982455d631c9d68a3273d9eb55885c
 
+# Special case disconnected checkouts, e.g. 'git checkout <tag>'
+(detached.*
+
 # every other branch is a development branch and thus gets resolved to 1.3.0-dev for now
 .*          1.3.0 198d3450d94be1a2                         pep440-dev


### PR DESCRIPTION
When doing 'git checkout <rev>' or 'git checkout <tag>' there will be no
branch info:

	$ git branch
	* (detached from 96fc70b)

After whitelisting '\(detached.*' we get:

	$ python setup.py version
	running version
	got version from git {'version': '1.2.5-1-gfd73e02', 'branch': 'HEAD',
	'full': 'fd73e02f4fa9f286407ad688feeeee3ebaffea60'}
	Version is currently: 1.2.5-1-gfd73e02

The '-1-gfd73e02' is this commit on top of the 1.2.5 tag.

While detached checkouts should be discouraged some buildsystems (e.g.
OpenEmbedded) have no real way to avoid it, which is what this patch
fixes. Actual people doing a checkout should use a branch.

Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>