### PR TITLE
Fix checks with os.path.realpath() for systems with symlinked paths

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -53,6 +53,7 @@ date of first contribution):
   * [Andrew Erickson](https://github.com/aerickson)
   * [Nicanor Romero Venier](https://github.com/nicanor-romero)
   * [Thomas Hou](https://github.com/masterhou)
+  * [Mark Bastiaans](https://github.com/markbastiaans)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -1072,7 +1072,7 @@ class Settings(object):
 	def saveScript(self, script_type, name, script):
 		script_folder = self.getBaseFolder("scripts")
 		filename = os.path.realpath(os.path.join(script_folder, script_type, name))
-		if not filename.startswith(script_folder):
+		if not filename.startswith(os.path.realpath(script_folder)):
 			# oops, jail break, that shouldn't happen
 			raise ValueError("Invalid script path to save to: {filename} (from {script_type}:{name})".format(**locals()))
 

--- a/src/octoprint/slicing/__init__.py
+++ b/src/octoprint/slicing/__init__.py
@@ -585,7 +585,7 @@ class SlicingManager(object):
 		name = self._sanitize(name)
 
 		path = os.path.join(self.get_slicer_profile_path(slicer), "{name}.profile".format(name=name))
-		if not os.path.realpath(path).startswith(self._profile_path):
+		if not os.path.realpath(path).startswith(os.path.realpath(self._profile_path)):
 			raise IOError("Path to profile {name} tried to break out of allows sub path".format(**locals()))
 		if must_exist and not (os.path.exists(path) and os.path.isfile(path)):
 			raise UnknownProfile(slicer, name)


### PR DESCRIPTION
I'm working on getting a recent version of Octoprint (1.2.6) packaged for Synology NASes in [SynoCommunity/spksrc](https://github.com/SynoCommunity/spksrc). I've gotten it to work after some tinkering, but it needed two trivial fixes to work with Synology's habit of putting packages in a symlinked location. Specifically, two checks using `os.path.realpath()` fail on Synology's OS while they shouldn't be.

I've not filed a bug report for this yet, let me know if I should. I've tested the fix on Synology only but I think the fix is so trivial that it won't will negatively impact other platforms.