### PR TITLE
Include a time estimate for gcode which uses firmware retract

### DIFF
--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -54,6 +54,9 @@ class gcode(object):
 		absoluteE = True
 		scale = 1.0
 		posAbs = True
+		fwretractTime = 0
+		fwretractDist = 0
+		fwrecoverTime = 0
 		feedRateXY = min(printer_profile["axes"]["x"]["speed"], printer_profile["axes"]["y"]["speed"])
 		if feedRateXY == 0:
 			# some somewhat sane default if axes speeds are insane...
@@ -172,6 +175,10 @@ class gcode(object):
 					P = getCodeFloat(line, 'P')
 					if P is not None:
 						totalMoveTimeMinute += P / 60.0 / 1000.0
+				elif G == 10:   #Firmware retract
+					totalMoveTimeMinute += fwretractTime
+				elif G == 11:   #Firmware retract recover
+					totalMoveTimeMinute += fwrecoverTime
 				elif G == 20:	#Units are inches
 					scale = 25.4
 				elif G == 21:	#Units are mm
@@ -214,6 +221,15 @@ class gcode(object):
 					absoluteE = True
 				elif M == 83:   #Relative E
 					absoluteE = False
+				elif M == 207 or M == 208: #Firmware retract settings
+					s = getCodeFloat(line, 'S')
+					f = getCodeFloat(line, 'F')
+					if s is not None and f is not None:
+						if M == 207:
+							fwretractTime = s / f
+							fwretractDist = s
+						else:
+							fwrecoverTime = (fwretractDist + s) / f
 
 			elif T is not None:
 				if T > settings().getInt(["gcodeAnalysis", "maxExtruders"]):


### PR DESCRIPTION
If firmware retraction is used, OctoPrint assumes that retract and recover operations are instantaneous. This patch accounts for retract times of G10 and recover times of G11. This relies on the retraction settings being seen in the gcode file such as
```
M207 S2.25 F2400
M208 S-0.1 F1200
```

It might not be a terrible idea to default fwretractTime and fwrecoverTime to something like 0.1s in case the user doesn't have their settings in the gcode. 

1. What were you doing? 3D printing and the time estimate was off for my printer using firmware retraction

2. What did you expect to happen? OctoPrint to take into account the time it takes to retract/recover.

3. What happened instead? It ignored the G10 and G11 commands! The nerve.

4. Branch & Commit or Version of OctoPrint: devel branch as of today Sept-12

5. Printer model & used firmware incl. version My Printer My Rules, smoothieware firmware
   (if applicable - always include if unsure):

6. Browser and Version of Browser, Operating 
   System running Browser (if applicable - always 
   include if unsure):Chrome on Windows 10

7. Link to octoprint.log on gist.github.com or pastebin.com
   (ALWAYS INCLUDE AND DO NOT TRUNCATE):Eeeee how about if a draw a log out of ASCII? (======O  Sort of?

8. Link to contents of terminal tab or serial.log on 
   gist.github.com or pastebin.com (if applicable - always 
   include if unsure or reporting communication issues AND
   DO NOT TRUNCATE): Oh boy.

9. Link to contents of Javascript console in the browser 
   on gist.github.com or pastebin.com or alternatively a
   screenshot (if applicable - always include if unsure
   or reporting UI issues): Goodness gracious

10. Screenshot(s) showing the problem (if applicable - always
    include if unsure or reporting UI issues): 
![image](https://cloud.githubusercontent.com/assets/677183/9832271/be8cc188-5943-11e5-8d1a-90e8e66a20f1.png)

I have read the FAQ.