### PR TITLE
changed magic line from python->python2

### DIFF
--- a/run
+++ b/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding=utf-8
 
 from setuptools import setup, find_packages

--- a/src/octoprint/__init__.py
+++ b/src/octoprint/__init__.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+
 import sys
 from octoprint.daemon import Daemon
 from octoprint.server import Server


### PR DESCRIPTION
Since python is sometimes (and for me on arch linux) a symlink to the
python3 utils, you should be more explicit with that.
