### PR TITLE
Prevent cutoff of Flot's y-axis markers when using responsive CSS

### DIFF
--- a/src/octoprint/templates/tabs/temperature.jinja2
+++ b/src/octoprint/templates/tabs/temperature.jinja2
@@ -1,5 +1,5 @@
 {% if enableTemperatureGraph %}
-    <div class="row" style="padding-left: 20px">
+    <div class="row-fluid">
         <div id="temperature-graph"></div>
     </div>
 {% endif %}


### PR DESCRIPTION
When using the Bootstrap responsive CSS manually or the ScreenSquish plugin, the y-axis markers get cutoff. This simple change prevents conflict.

![image](https://cloud.githubusercontent.com/assets/10536167/10850149/77fadc3c-7efa-11e5-8c9f-02b1331a5adc.png)
