### PR TITLE
Allow octoprint.comm.protocol.gcode.queuing hook to return a list of commands

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -56,6 +56,7 @@ date of first contribution):
   * [Mark Bastiaans](https://github.com/markbastiaans)
   * [Marcel Hellwig](https://github.com/punkkeks)
   * [Kevin Murphy](https://github.com/kevingelion)
+  * [Goswin von Brederlow](https://github.com/mrvn)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/plugins/hooks.rst
+++ b/docs/plugins/hooks.rst
@@ -275,6 +275,12 @@ This describes actually four hooks:
        should use this option.
      * A 2-tuple consisting of a rewritten version of the ``cmd`` and the ``cmd_type``, e.g. ``return "M105", "temperature_poll"``.
        Handlers which wish to rewrite both the command and the command type should use this option.
+     * Queuing only: A list of strings replacing the command with a series of commands of the same ``cmd_type``.
+     * Queuing only: A list of 2-tuple replacing the command with a series of commands with new ``cmd_type``. This allows
+       replacing a command with a series of commands of different type.
+
+     Note: Only one command of a given ``cmd_type`` (other than None) may be queued at a time. Trying to rewrite the ``cmd_type``
+     to one already in the queue will give an error. 
 
    **Example**
 


### PR DESCRIPTION
The M3D Micro plugin comes with a Z compensation that replaces single G1 commands with a series of smaller G1 commands with adjusted Z value. For this to work cleanly the octoprint.comm.protocol.gcode.queuing hook needs to return a list of commands.

The pull request theoretically also allows the octoprint.comm.protocol.gcode.sending hook to return a list of commands but at that point the line number is already chosen and expanding a command would mess that up. Therefore the code asserts that commands from sending are not expanded to multiple commands and only documents the new feature for queuing. This breaks backward compatibility for plugins returning a list instead of a tuple in their octoprint.comm.protocol.gcode hooks. But the API documentation clearly says to return a tuple.
