### PR TITLE
Intermediary page: Incorrect image url with hashtags and different reload method

### DIFF
--- a/src/octoprint/static/intermediary.html
+++ b/src/octoprint/static/intermediary.html
@@ -132,7 +132,7 @@
                 var intervals = [1, 1, 2, 3, 5, 8];
                 var timeout = 1500;
 
-                var baseUrl = window.location.href;
+                var baseUrl = window.location.href.replace(window.location.hash, "");
                 if (baseUrl.indexOf("/static") > -1) {
                     baseUrl = baseUrl.substring(0, baseUrl.indexOf("/static")) + "/";
                 }
@@ -150,7 +150,7 @@
                         serverIsOnline = true;
                         message.className = "pulsate1 green";
                         message.innerText = "OctoPrint server online, reloading page...";
-                        window.location = baseUrl;
+                        window.location.reload();
                     } else {
                         // online.gif still not available, let's look at
                         var interval = 15;

--- a/src/octoprint/static/intermediary.html
+++ b/src/octoprint/static/intermediary.html
@@ -132,9 +132,12 @@
                 var intervals = [1, 1, 2, 3, 5, 8];
                 var timeout = 1500;
 
-                var baseUrl = window.location.href.replace(window.location.hash, "");
+                var baseUrl = window.location.href;
                 if (baseUrl.indexOf("/static") > -1) {
                     baseUrl = baseUrl.substring(0, baseUrl.indexOf("/static")) + "/";
+                }
+                if (baseUrl.indexOf("#") > -1) {
+                    baseUrl = baseUrl.substring(0, baseUrl.indexOf("#"));
                 }
                 var serverOnlineUrl = baseUrl + "online.gif";
                 var backendOnlineUrl = baseUrl + "intermediary.gif";


### PR DESCRIPTION
Yet Another PR... :+1:

1. __Prevent hash tag from generating incorrect image url__
If you start with the Intermediary page and you have a hashtag in your url then the script would make it ``http://localhost:5000/#touchonline.gif``. This would also make the start screen show an incorrect error. (Because it failed to load the image which the normal url would have responded on.)

1. __Use reload method to leave url intact__
In addition to removing the hashtag, I also used location.reload to keep the URL intact, e.g. If someone  made a plugin that would remember the tab state by adding hashtag to the URL.