### PR TITLE
Initialize loginUser and loginPass with an empty string

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/loginstate.js
+++ b/src/octoprint/static/js/app/viewmodels/loginstate.js
@@ -2,8 +2,8 @@ $(function() {
     function LoginStateViewModel() {
         var self = this;
 
-        self.loginUser = ko.observable();
-        self.loginPass = ko.observable();
+        self.loginUser = ko.observable("");
+        self.loginPass = ko.observable("");
         self.loginRemember = ko.observable(false);
 
         self.loggedIn = ko.observable(false);
@@ -79,10 +79,6 @@ $(function() {
             var password = self.loginPass();
             var remember = self.loginRemember();
 
-            self.loginUser("");
-            self.loginPass("");
-            self.loginRemember(false);
-
             $.ajax({
                 url: API_BASEURL + "login",
                 type: "POST",
@@ -90,6 +86,10 @@ $(function() {
                 success: function(response) {
                     new PNotify({title: gettext("Login successful"), text: _.sprintf(gettext('You are now logged in as "%(username)s"'), {username: response.name}), type: "success"});
                     self.fromResponse(response);
+
+                    self.loginUser("");
+                    self.loginPass("");
+                    self.loginRemember(false);
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
                     new PNotify({title: gettext("Login failed"), text: gettext("User unknown or wrong password"), type: "error"});


### PR DESCRIPTION
In this PR:
 1. __Initialize loginUser and loginPass with an empty string__
 If you login without entering any information then jQuery would succeed the failed AJAX request and tries to add the notification with "Login succes" but generates the following javascript error:
 ````
Uncaught TypeError: Cannot read property 'name' of undefined
     $.ajax.success @ packed_app.js?35ab948d:1599
     l @ packed_libs.js?1bb5f6cd:3
     c.fireWith @ packed_libs.js?1bb5f6cd:3
     k @ packed_libs.js?1bb5f6cd:5
     (anonymous function) @ packed_libs.js?1bb5f6cd:5
````

 Strangely I noticed that the second post without entering information wouldn't trigger an error, I found out that was because during the post the observable where reset to an empty string. (so if we initialize with an empty string it wouldn't trigger the success function the first too)

 1. __Clear loginUser and loginPass after a successful login__
 A small usability thing, but very useful, I find it very annoying if I mistyped something to redo all the inputs, let the user control this. If this is to much for the maintenance branch then I can cherry pick this out ofcourse.