### PR TITLE
Fix missing kwargs in PluginSettings remove

### DIFF
--- a/src/octoprint/plugin/__init__.py
+++ b/src/octoprint/plugin/__init__.py
@@ -330,7 +330,7 @@ class PluginSettings(object):
 			set_int    =("setInt",     prefix_path_in_args, add_setter_kwargs),
 			set_float  =("setFloat",   prefix_path_in_args, add_setter_kwargs),
 			set_boolean=("setBoolean", prefix_path_in_args, add_setter_kwargs),
-			remove     =("remove",     prefix_path_in_args)
+			remove     =("remove",     prefix_path_in_args, lambda x: x)
 		)
 		self.deprecated_access_methods = dict(
 			getInt    ="get_int",


### PR DESCRIPTION
Trying to run `self._settings.remove(path)` in a plugin caused the following error before:
```
File "OctoPrint/src/octoprint/plugin/__init__.py", line 475, in __getattr__
    settings_name, args_mapper, kwargs_mapper = self.access_methods[item]
ValueError: need more than 2 values to unpack
```

This simply adds the third `kwargs_mapper` value as a passthrough lambda function, allowing remove to function as intended.