### PR TITLE
knockout: Multiple ways of registering your code + Optional dependencies

### DIFF
--- a/src/octoprint/static/js/app/main.js
+++ b/src/octoprint/static/js/app/main.js
@@ -252,8 +252,8 @@ $(function() {
             while (unprocessedViewModels.length > 0){
                 var viewModel = unprocessedViewModels.shift();
 
-                // wrap anything not object related into an object (use jQuery since lodash returns invalid results)
-                if(!$.isPlainObject(viewModel)) {
+                // wrap anything not object related into an object
+                if(!_.isPlainObject(viewModel)) {
                     viewModel = {
                         construct: (_.isArray(viewModel)) ? viewModel[0] : viewModel,
                         dependencies: viewModel[1] || [],

--- a/src/octoprint/static/js/app/main.js
+++ b/src/octoprint/static/js/app/main.js
@@ -252,7 +252,7 @@ $(function() {
             while (unprocessedViewModels.length > 0){
                 var viewModel = unprocessedViewModels.shift();
 
-                // wrap anything not object related into a object (use jQuery since lodash returns invalid results)
+                // wrap anything not object related into an object (use jQuery since lodash returns invalid results)
                 if(!$.isPlainObject(viewModel)) {
                     viewModel = {
                         construct: (_.isArray(viewModel)) ? viewModel[0] : viewModel,
@@ -268,8 +268,8 @@ $(function() {
                     continue;
                 }
 
-                // if name is not set, get name from construct, if it's an anonymous function; generate one
-                viewModel.name = viewModel.name || _getViewModelId(viewModel.construct.name) || "unnamedViewModel" + _.uniqueId();
+                // if name is not set, get name from constructor, if it's an anonymous function generate one
+                viewModel.name = viewModel.name || _getViewModelId(viewModel.construct.name) || _.uniqueId("unnamedViewModel");
 
                 // make sure all value's are in an array
                 viewModel.dependencies = (_.isArray(viewModel.dependencies)) ? viewModel.dependencies : [viewModel.dependencies];

--- a/src/octoprint/static/js/app/main.js
+++ b/src/octoprint/static/js/app/main.js
@@ -199,11 +199,8 @@ $(function() {
                 constructorParameters = [];
             }
 
-            if (_.some(constructorParameters, function(parameter) { return parameter === undefined; })) {
-                var _extractName = function(entry) { return entry[0]; };
-                var _onlyUnresolved = function(entry) { return entry[1] === undefined; };
-                var missingParameters = _.map(_.filter(_.zip(viewModelParameters, constructorParameters), _onlyUnresolved), _extractName);
-                log.debug("Postponing", viewModel[0].name, "due to missing parameters:", missingParameters);
+            if (constructorParameters.indexOf(undefined) !== -1) {
+                log.debug("Postponing", viewModel[0].name, "due to missing parameters:", _.keys(_.pick(_.object(viewModelParameters, constructorParameters), _.isUndefined)));
                 return;
             }
 

--- a/src/octoprint/static/js/app/main.js
+++ b/src/octoprint/static/js/app/main.js
@@ -204,7 +204,7 @@ $(function() {
             }
 
             // transform array into object if a plugin wants it as an object
-            constructorParameters = (viewModel.format === "object") ? _.object(viewModel.dependencies, constructorParameters) : constructorParameters;
+            constructorParameters = (viewModel.returnObject) ? _.object(viewModel.dependencies, constructorParameters) : constructorParameters;
 
             // if we came this far then we could resolve all constructor parameters, so let's construct that view model
             log.debug("Constructing", viewModel.name, "with parameters:", viewModel.dependencies);


### PR DESCRIPTION
Beside my commitment, I refactored a bit of the processing, so please double check the CR :smile: 

**Extending OCTOPRINT_VIEWMODELS**

1. Allow multiple way's of registering your code to OctoPrint

    1. Objects:
         ````
        OCTOPRINT_VIEWMODELS.push({
             construct: function namedViewModel() {},
             dependencies: [vm1, vm2],
             elements: [el1, el2],
             optional: [vm1, vm2],
             returnObject: true
       });
         ````

    1. Functions:

       ````
      OCTOPRINT_VIEWMODELS.push(function namedViewModel() {});
       ````

    1. Even anonymous:
       ````
      OCTOPRINT_VIEWMODELS.push(function() {});
       ````
1. Add optional dependencies:

    - Allow an 4th parameter in the array OCTOPRINT_VIEWMODELS

       ````
      OCTOPRINT_VIEWMODELS.push([
           function namedViewModel() {},
           [vm1, vm2],
           [el1, el2],
           [vm1, vm2]
      ]);
       ````

1. Add option `returnObject: true` to return an object instead of an array:
    
    ````
    {
        settingsViewModel: function settingsViewModel,
        softwareUpdateViewModel: function softwareUpdateViewModel
    }
    ````

1. All options (dependencies, elements, optional, returnObject) are optional. The constructor is required. (throws error when undefined)


*TODO (Will create another PR after discussion/feedback/etc): Update ``docs/plugins/viewmodels.rst``*