### PR TITLE
allow download/management of mp4 timelapse too

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -366,7 +366,8 @@ class Server():
 
 		server_routes = self._router.urls + [
 			# various downloads
-			(r"/downloads/timelapse/([^/]*\.mpg)", util.tornado.LargeResponseHandler, joined_dict(dict(path=self._settings.getBaseFolder("timelapse")),
+			# .mpg and .mp4 timelapses:
+			(r"/downloads/timelapse/([^/]*\.mp[g4])", util.tornado.LargeResponseHandler, joined_dict(dict(path=self._settings.getBaseFolder("timelapse")),
 			                                                                                      download_handler_kwargs,
 			                                                                                      no_hidden_files_validator)),
 			(r"/downloads/files/local/(.*)", util.tornado.LargeResponseHandler, joined_dict(dict(path=self._settings.getBaseFolder("uploads")),

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -62,7 +62,7 @@ def get_finished_timelapses():
 	files = []
 	basedir = settings().getBaseFolder("timelapse")
 	for osFile in os.listdir(basedir):
-		if not fnmatch.fnmatch(osFile, "*.mpg"):
+		if not fnmatch.fnmatch(osFile, "*.mp[g4]"):
 			continue
 		statResult = os.stat(os.path.join(basedir, osFile))
 		files.append({


### PR DESCRIPTION
in support of issue https://github.com/guysoft/OctoPi/issues/184 , small PR to allow octoprint to manage (and download) mp4 files created with encoding wrapper scripts