### PR TITLE
Format temperatures in Fahrenheit as well.

### DIFF
--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -413,7 +413,7 @@ function cleanTemperature(temp) {
 
 function formatTemperature(temp) {
     if (!temp || temp < 10) return gettext("off");
-    return _.sprintf("%.1f&deg;C", temp);
+    return _.sprintf("%.1f&deg;C (%.1f&deg;F)", temp, temp * 9 / 5 + 32);
 }
 
 function pnotifyAdditionalInfo(inner) {


### PR DESCRIPTION
For Americans who grew up using Fahrenheit, it's difficult to glance at temperatures in Celsius and decide if it is safe to touch the hotend or the bed.  This adds temperatures in Fahrenheit in parenthesis after the temperature in Celsius.