### PR TITLE
Add output in Fahrenheit as well as Celsius.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -60,6 +60,7 @@ date of first contribution):
   * ["bwgan"](https://github.com/bwgan)
   * [Siim Raud](https://github.com/2ndalpha)
   * ["geoporalis"](https://github.com/geoporalis)
+  * [therealbstern](https://github.com/therealbstern)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -207,6 +207,7 @@ default_settings = {
 		"color": "default",
 		"colorTransparent": False,
 		"defaultLanguage": "_default",
+		"showFahrenheitAlso": False,
 		"components": {
 			"order": {
 				"navbar": ["settings", "systemmenu", "login"],

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -413,7 +413,7 @@ function cleanTemperature(temp) {
 
 function formatTemperature(temp) {
     if (!temp || temp < 10) return gettext("off");
-    return _.sprintf("%.1f&deg;C", temp);
+    return _.sprintf("%.1f&deg;C (%.1f&deg;F)", temp, temp * 9 / 5 + 32);
 }
 
 function pnotifyAdditionalInfo(inner) {

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -411,9 +411,13 @@ function cleanTemperature(temp) {
     return temp;
 }
 
-function formatTemperature(temp) {
+function formatTemperature(temp, showF) {
     if (!temp || temp < 10) return gettext("off");
-    return _.sprintf("%.1f&deg;C (%.1f&deg;F)", temp, temp * 9 / 5 + 32);
+    if (showF) {
+        return _.sprintf("%.1f&deg;C (%.1f&deg;F)", temp, temp * 9 / 5 + 32);
+    } else {
+        return _.sprintf("%.1f&deg;C", temp);
+    }
 }
 
 function pnotifyAdditionalInfo(inner) {

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -100,6 +100,7 @@ $(function() {
         self.appearance_color = ko.observable(undefined);
         self.appearance_colorTransparent = ko.observable();
         self.appearance_defaultLanguage = ko.observable();
+        self.appearance_showFahrenheitAlso = ko.observable(undefined);
 
         self.printer_defaultExtrusionLength = ko.observable(undefined);
 

--- a/src/octoprint/static/js/app/viewmodels/temperature.js
+++ b/src/octoprint/static/js/app/viewmodels/temperature.js
@@ -248,8 +248,9 @@ $(function() {
                         targets = self.temperatures[type].target;
                     }
 
-                    var actualTemp = actuals && actuals.length ? formatTemperature(actuals[actuals.length - 1][1]) : "-";
-                    var targetTemp = targets && targets.length ? formatTemperature(targets[targets.length - 1][1]) : "-";
+                    var showFahrenheit = self.settingsViewModel.settings.appearance.showFahrenheitAlso();
+                    var actualTemp = actuals && actuals.length ? formatTemperature(actuals[actuals.length - 1][1], showFahrenheit) : "-";
+                    var targetTemp = targets && targets.length ? formatTemperature(targets[targets.length - 1][1], showFahrenheit) : "-";
 
                     data.push({
                         label: gettext("Actual") + " " + heaterOptions[type].name + ": " + actualTemp,

--- a/src/octoprint/templates/dialogs/settings/appearance.jinja2
+++ b/src/octoprint/templates/dialogs/settings/appearance.jinja2
@@ -36,6 +36,13 @@
             <span class="help-inline">{{ _('Changes to the default interface language will only become active after a reload of the page and only be active if not overridden by the user''s language settings.') }}</span>
         </div>
     </div>
+    <div class="control-group">
+        <div class="controls">
+            <label class="checkbox">
+                <input type="checkbox" data-bind="checked: appearance_showFahrenheitAlso" id="settings-appearanceShowFahrenheitAlso"> {{ _('Show temperatures in Fahrenheit as well as Celcius') }}
+            </label>
+        </div>
+    </div>
 </form>
 
 <div id="settings_appearance_managelanguagesdialog" class="modal hide fade">


### PR DESCRIPTION
For Americans who grew up using Fahrenheit, it's difficult to glance at temperatures in Celsius and decide if it is safe to touch the hotend or the bed. This adds temperatures in Fahrenheit in parenthesis after the temperature in Celsius.