### PR TITLE
Added pause support for rf1000 and rf2000 printer M307[01] GCodes

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -150,10 +150,10 @@ gcodeToEvent = {
 	"M0": Events.WAITING,
 	"M1": Events.WAITING,
 
-    # rfXXX printer pause
-    # see: http://www.rf1000.de/wiki/index.php/GCodes#M3070_-_Druck_pausieren_.28als_ob_Pause-Taste_gedr.C3.BCckt_wurde.29
-    "M3070": Events.WAITING,
-    "M3071": Events.WAITING,
+	# rfXXX printer pause
+	# see: http://www.rf1000.de/wiki/index.php/GCodes#M3070_-_Druck_pausieren_.28als_ob_Pause-Taste_gedr.C3.BCckt_wurde.29
+	"M3070": Events.WAITING,
+	"M3071": Events.WAITING,
 
 	# dwell command
 	"G4": Events.DWELL,
@@ -1970,8 +1970,8 @@ class MachineCom(object):
 		if self.isPrinting() and not self.isSdPrinting():
 			self.setPause(True)
 
-    _gcode_M3070_queuing = _gcode_M25_queuing # additions for rfxxx printer
-    _gcode_M3071_queuing = _gcode_M25_queuing
+	_gcode_M3070_queuing = _gcode_M25_queuing # additions for rfxxx printer
+	_gcode_M3071_queuing = _gcode_M25_queuing
 
 	def _gcode_M28_sent(self, cmd, cmd_type=None):
 		if not self.isStreaming():

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -149,6 +149,12 @@ gcodeToEvent = {
 	"M226": Events.WAITING,
 	"M0": Events.WAITING,
 	"M1": Events.WAITING,
+
+    # rfXXX printer pause
+    # see: http://www.rf1000.de/wiki/index.php/GCodes#M3070_-_Druck_pausieren_.28als_ob_Pause-Taste_gedr.C3.BCckt_wurde.29
+    "M3070": Events.WAITING,
+    "M3071": Events.WAITING,
+
 	# dwell command
 	"G4": Events.DWELL,
 
@@ -1963,6 +1969,9 @@ class MachineCom(object):
 		# for GCODE induced pausing. Send it to the printer anyway though.
 		if self.isPrinting() and not self.isSdPrinting():
 			self.setPause(True)
+
+    _gcode_M3070_queuing = _gcode_M25_queuing # additions for rfxxx printer
+    _gcode_M3071_queuing = _gcode_M25_queuing
 
 	def _gcode_M28_sent(self, cmd, cmd_type=None):
 		if not self.isStreaming():


### PR DESCRIPTION
not sure if this meets the guidelines, but i'll give it a try.
Added Support for the rf1000 and rf2000 Printers (Conrad Elektronik SE)
Additionally the following changes in config.yaml are necessary:
printerParameters:
  pauseTriggers:
  - regex: continuePrint
    type: disable
  - regex: pausePrint
    type: enable
i'd love to configure this within printer profiles of course ;)

btw. thanks Gina for octoprint and having the SD Upload back ! it was (even for me not being a python guy) very easy to read and understand your code / and that is - of course all i.m.O. - a sign for high quality code!