### PR TITLE
Added setting to change GCode-visualizer file size threshold to ui #1145

### DIFF
--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -60,6 +60,8 @@ def getSettings():
 		},
 		"feature": {
 			"gcodeViewer": s.getBoolean(["gcodeViewer", "enabled"]),
+			"sizeThreshold": s.getInt(["gcodeViewer", "sizeThreshold"]),
+			"mobileSizeThreshold": s.getInt(["gcodeViewer", "mobileSizeThreshold"]),
 			"temperatureGraph": s.getBoolean(["feature", "temperatureGraph"]),
 			"waitForStart": s.getBoolean(["feature", "waitForStartOnConnect"]),
 			"alwaysSendChecksum": s.getBoolean(["feature", "alwaysSendChecksum"]),
@@ -218,6 +220,8 @@ def _saveSettings(data):
 
 	if "feature" in data.keys():
 		if "gcodeViewer" in data["feature"].keys(): s.setBoolean(["gcodeViewer", "enabled"], data["feature"]["gcodeViewer"])
+		if "sizeThreshold" in data["feature"].keys(): s.setInt(["gcodeViewer", "sizeThreshold"], data["feature"]["sizeThreshold"])
+		if "mobileSizeThreshold" in data["feature"].keys(): s.setInt(["gcodeViewer", "mobileSizeThreshold"], data["feature"]["mobileSizeThreshold"])
 		if "temperatureGraph" in data["feature"].keys(): s.setBoolean(["feature", "temperatureGraph"], data["feature"]["temperatureGraph"])
 		if "waitForStart" in data["feature"].keys(): s.setBoolean(["feature", "waitForStartOnConnect"], data["feature"]["waitForStart"])
 		if "alwaysSendChecksum" in data["feature"].keys(): s.setBoolean(["feature", "alwaysSendChecksum"], data["feature"]["alwaysSendChecksum"])

--- a/src/octoprint/server/views.py
+++ b/src/octoprint/server/views.py
@@ -389,6 +389,7 @@ def _process_templates():
 
 		features=(gettext("Features"), dict(template="dialogs/settings/features.jinja2", _div="settings_features", custom_bindings=False)),
 		webcam=(gettext("Webcam & Timelapse"), dict(template="dialogs/settings/webcam.jinja2", _div="settings_webcam", custom_bindings=False)),
+		gcodevisualizer=(gettext("GCODE Visualizer"), dict(template="dialogs/settings/gcodevisualizer.jinja2", _div="settings_gcodegcodevisualizer", custom_bindings=False)),
 		api=(gettext("API"), dict(template="dialogs/settings/api.jinja2", _div="settings_api", custom_bindings=False)),
 
 		section_octoprint=(gettext("OctoPrint"), None),

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -219,7 +219,7 @@ default_settings = {
 				"tab": ["temperature", "control", "gcodeviewer", "terminal", "timelapse"],
 				"settings": [
 					"section_printer", "serial", "printerprofiles", "temperatures", "terminalfilters", "gcodescripts",
-					"section_features", "features", "webcam", "accesscontrol", "api",
+					"section_features", "features", "webcam", "accesscontrol", "gcodevisualizer", "api",
 					"section_octoprint", "server", "folders", "appearance", "logs", "plugin_pluginmanager", "plugin_softwareupdate"
 				],
 				"usersettings": ["access", "interface"],

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -114,6 +114,10 @@ $(function() {
         self.webcam_rotate90 = ko.observable(undefined);
 
         self.feature_gcodeViewer = ko.observable(undefined);
+        self.feature_sizeThreshold = ko.observable();
+        self.feature_mobileSizeThreshold = ko.observable();
+        self.feature_sizeThreshold_str = sizeObservable(self.feature_sizeThreshold);
+        self.feature_mobileSizeThreshold_str = sizeObservable(self.feature_mobileSizeThreshold);
         self.feature_temperatureGraph = ko.observable(undefined);
         self.feature_waitForStart = ko.observable(undefined);
         self.feature_sendChecksum = ko.observable("print");

--- a/src/octoprint/templates/dialogs/settings/features.jinja2
+++ b/src/octoprint/templates/dialogs/settings/features.jinja2
@@ -8,14 +8,7 @@
     </div>
     <div class="control-group">
         <div class="controls">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: feature_gcodeViewer" id="settings-featureGcodeViewer"> {{ _('Enable GCode Visualizer') }}
-            </label>
-        </div>
-    </div>
-    <div class="control-group">
-        <div class="controls">
-            <label class="checkbox">
+			<label class="checkbox">
                 <input type="checkbox" data-bind="checked: feature_sdSupport" id="settings-featureSdSupport"> {{ _('Enable SD support') }}
             </label>
         </div>

--- a/src/octoprint/templates/dialogs/settings/gcodevisualizer.jinja2
+++ b/src/octoprint/templates/dialogs/settings/gcodevisualizer.jinja2
@@ -1,0 +1,24 @@
+<form class="form-horizontal">
+    <div class="control-group">
+        <div class="controls">
+            <label class="checkbox">
+                <input type="checkbox" data-bind="checked: feature_gcodeViewer" id="settings-featureGcodeViewer"> {{ _('Enable GCode Visualizer') }}
+            </label>
+        </div>
+    </div>
+    <div class="control-group" title="{{ _('Maximum size the GCodeViewer autoloads the file for preview') }}">
+        <label class="control-label" for="settings-gcodeviewer">{{ _('GCode Visualizer file size threshold') }}</label>
+        <div class="controls">
+            <div class="input-append">
+                    <input type="text" class="input-mini text-right" data-bind="value: feature_sizeThreshold_str">
+            </div>
+            <span class="help-inline">{{ _('on desktop')}}</span>
+        </div>
+        <div class="controls">
+            <div class="input-append">
+                 <input type="text" class="input-mini text-right" data-bind="value: feature_mobileSizeThreshold_str">
+            </div>
+            <span class="help-inline">{{ _('on mobile')}}</span>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
It adds the ability to change the file size threshold of the gcode visualizer in the ui settings.
It also moved the gcode settings to a new tab.
#### How was it tested? How can it be tested by the reviewer?
I tested on my machine with multiple files and different settings. It can be tested with the virtual printer, adding some Gcode-Files with different file sizes and load them.
#### Any background context you want to provide?

#### What are the relevant tickets if any?
#1145 
#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/816293/14437166/36843706-0020-11e6-9816-4a8811e2f69d.png)
#### Further notes 