### PR TITLE
Make Server class octoprint_daemon-aware, make sure terminated() gets…

### DIFF
--- a/src/octoprint/cli/server.py
+++ b/src/octoprint/cli/server.py
@@ -11,7 +11,7 @@ import sys
 
 from octoprint.cli import pass_octoprint_ctx, bulk_options, standard_options
 
-def run_server(basedir, configfile, host, port, debug, allow_root, logging_config, verbosity):
+def run_server(basedir, configfile, host, port, debug, allow_root, logging_config, verbosity, octoprint_daemon = None):
 	"""Initializes the environment and starts up the server."""
 
 	from octoprint import init_platform, __display_version__
@@ -38,7 +38,7 @@ def run_server(basedir, configfile, host, port, debug, allow_root, logging_confi
 	                                            after_logging=log_startup)
 
 	from octoprint.server import Server
-	octoprint_server = Server(settings=settings, plugin_manager=plugin_manager, host=host, port=port, debug=debug, allow_root=allow_root)
+	octoprint_server = Server(settings=settings, plugin_manager=plugin_manager, host=host, port=port, debug=debug, allow_root=allow_root, octoprint_daemon=octoprint_daemon)
 	octoprint_server.run()
 
 #~~ server options
@@ -114,7 +114,7 @@ def daemon_command(octoprint_ctx, pid, host, port, logging, allow_root, debug, c
 			self._verbosity = verbosity
 
 		def run(self):
-			run_server(self._basedir, self._configfile, self._host, self._port, self._debug, self._allow_root, self._logging_config, self._verbosity)
+			run_server(self._basedir, self._configfile, self._host, self._port, self._debug, self._allow_root, self._logging_config, self._verbosity, self)
 
 	octoprint_daemon = OctoPrintDaemon(pid, octoprint_ctx.basedir, octoprint_ctx.configfile,
 	                                   host, port, debug, allow_root, logging, octoprint_ctx.verbosity)

--- a/src/octoprint/daemon.py
+++ b/src/octoprint/daemon.py
@@ -31,9 +31,6 @@ class Daemon:
 		pid = str(os.getpid())
 		self.set_pid(pid)
 
-		# register listener for SIGTERM
-		signal.signal(signal.SIGTERM, self._on_sigterm)
-
 	def _double_fork(self):
 		try:
 			pid = os.fork()
@@ -71,10 +68,8 @@ class Daemon:
 		os.dup2(so.fileno(), sys.stdout.fileno())
 		os.dup2(se.fileno(), sys.stderr.fileno())
 
-	def _on_sigterm(self, _signo, _stack_frame):
-		"""Signal handler for SIGTERM, deletes the pidfile."""
+	def terminated(self):
 		self.remove_pidfile()
-		sys.exit(0)
 
 	def start(self):
 		"""Start the daemon."""

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -113,13 +113,14 @@ def load_user(id):
 
 
 class Server(object):
-	def __init__(self, settings=None, plugin_manager=None, host="0.0.0.0", port=5000, debug=False, allow_root=False):
+	def __init__(self, settings=None, plugin_manager=None, host="0.0.0.0", port=5000, debug=False, allow_root=False, octoprint_daemon=None):
 		self._settings = settings
 		self._plugin_manager = plugin_manager
 		self._host = host
 		self._port = port
 		self._debug = debug
 		self._allow_root = allow_root
+		self._octoprint_daemon = octoprint_daemon
 		self._server = None
 
 		self._logger = None
@@ -521,6 +522,9 @@ class Server(object):
 		def sigterm_handler(*args, **kwargs):
 			# will stop tornado on SIGTERM, making the program exit cleanly
 			def shutdown_tornado():
+				if self._octoprint_daemon is not None:
+					self._octoprint_daemon.terminated()
+
 				ioloop.stop()
 			ioloop.add_callback_from_signal(shutdown_tornado)
 		signal.signal(signal.SIGTERM, sigterm_handler)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -157,23 +157,15 @@ class DaemonTest(unittest.TestCase):
 		self.daemon.set_pid.assert_called_once_with(str(pid))
 		mock_signal.assert_called_once_with(signal.SIGTERM, self.daemon._on_sigterm)
 
-	@mock.patch("sys.exit")
-	def test_on_sigterm(self, mock_exit):
+	def test_terminated(self):
 		# setup
 		self.daemon.remove_pidfile = mock.MagicMock()
 
-		mock_exit.side_effect = ExpectedExit
-
 		# test
-		try:
-			self.daemon._on_sigterm("foo", "bar")
-			self.fail("Expected an exit")
-		except ExpectedExit:
-			pass
+		self.daemon.terminated()
 
 		# assert
 		self.daemon.remove_pidfile.assert_called_once_with()
-		mock_exit.assert_called_once_with(0)
 
 	def test_start(self):
 		# setup

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -155,7 +155,6 @@ class DaemonTest(unittest.TestCase):
 		self.daemon._double_fork.assert_called_once_with()
 		self.daemon._redirect_io.assert_called_once_with()
 		self.daemon.set_pid.assert_called_once_with(str(pid))
-		mock_signal.assert_called_once_with(signal.SIGTERM, self.daemon._on_sigterm)
 
 	def test_terminated(self):
 		# setup


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR is for cleaning up the pidfile of a daemonized instance upon termination. This is my proposed solution to address issue #1324 

#### How was it tested? How can it be tested by the reviewer?

```
octoprint --daemon start --pid /tmp/octoprint.pid
kill -TERM `cat /tmp/octoprint.pid`
ls -l /tmp/octoprint.pid
```

#### What are the relevant tickets if any?
#1324 

#### Screenshots (if appropriate)

#### Further notes
This seems like the necessary solution for this case. The Server class handles clean-up and termination, so it seems to make the most sense to make it octoprint_daemon-aware and force a clean-up of the Daemon instance. The exit() is no longer needed, as the termination should otherwise be handled as it normally is (now). 