### PR TITLE
Corrects example URL in Slicing API Doc

### DIFF
--- a/docs/api/slicing.rst
+++ b/docs/api/slicing.rst
@@ -32,7 +32,7 @@ List All Slicers and Slicing Profiles
 
    .. sourcecode:: http
 
-      GET /api/slicing/profiles HTTP/1.1
+      GET /api/slicing HTTP/1.1
       Host: example.com
       X-Api-Key: abcdef...
 


### PR DESCRIPTION
This fixes a simple typo in the API doc for fetching slicing profiles. The previous example had /profiles appended to it, whereas it should just be /api/slicing to fetch a list of all slicers and profiles.
