### PR TITLE
Deletemp4

### DIFF
--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -38,7 +38,8 @@ def full_extension_tree():
 		),
 		# extensions for videos (timelapse)
 		video=dict(
-			mpeg=ContentTypeMapping(["mpeg", "mpg", "mp4"], "video/mpeg")
+			mpeg=ContentTypeMapping(["mpeg", "mpg"], "video/mpeg"),
+			mp4=ContentTypeMapping(["mp4"], "video/mp4")
 		)
 	)
 

--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -35,6 +35,10 @@ def full_extension_tree():
 		# extensions for printable machine code
 		machinecode=dict(
 			gcode=ContentTypeMapping(["gcode", "gco", "g"], "text/plain")
+		),
+		# extensions for videos (timelapse)
+		video=dict(
+			mpeg=ContentTypeMapping(["mpeg", "mpg", "mp4"], "video/mpeg")
 		)
 	)
 

--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -11,7 +11,6 @@ from flask import request, jsonify, url_for, make_response
 from werkzeug.utils import secure_filename
 
 import octoprint.timelapse
-import octoprint.util as util
 from octoprint.settings import settings, valid_boolean_trues
 
 from octoprint.server import admin_permission, printer
@@ -62,7 +61,7 @@ def downloadTimelapse(filename):
 @api.route("/timelapse/<filename>", methods=["DELETE"])
 @restricted_access
 def deleteTimelapse(filename):
-	if util.is_allowed_file(filename, ["mpg"]):
+	if octoprint.filemanager.valid_file_type(filename, type="mpeg"):
 		timelapse_folder = settings().getBaseFolder("timelapse")
 		full_path = os.path.realpath(os.path.join(timelapse_folder, filename))
 		if full_path.startswith(timelapse_folder) and os.path.exists(full_path):

--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -61,7 +61,7 @@ def downloadTimelapse(filename):
 @api.route("/timelapse/<filename>", methods=["DELETE"])
 @restricted_access
 def deleteTimelapse(filename):
-	if octoprint.filemanager.valid_file_type(filename, type="mpeg"):
+	if octoprint.filemanager.valid_file_type(filename, type="video"):
 		timelapse_folder = settings().getBaseFolder("timelapse")
 		full_path = os.path.realpath(os.path.join(timelapse_folder, filename))
 		if full_path.startswith(timelapse_folder) and os.path.exists(full_path):


### PR DESCRIPTION
The timelapse api has allowed mp4 timelapse files for a bit now, but it is impossible to delete them because the api only allows you to perform the DELETE request on files with extension ,mpg.

This pull request switches from the standard extension-based mapping to use the filemanager's `valid_file_type` method. A new type "video" has been added with the two mime types for mpeg and mp4.

Note that this is the last usage of util.is_allowed_file() in all of OctoPrint so that might be able to be removed if you're no longer going to use it (and prevent it from being used by contributors instead of the filemanager).

This should close the deletion portion of #1320, but the notification still does say .mpeg so that part is still open.