### PR TITLE
Some options for handling RepRapFirmware SD card behavior

### DIFF
--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -434,6 +434,9 @@ Use the following settings to enable or disable OctoPrint features:
      # Specifies whether support for SD printing and file management should be enabled
      sdSupport: true
 
+     # Specifies whether firmware expects relative paths for selecting SD files
+     sdRelativePath: false
+
      # Whether to always assume that an SD card is present in the printer.
      # Needed by some firmwares which don't report the SD card status properly.
      sdAlwaysAvailable: false

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -290,6 +290,14 @@ The following settings are only relevant to you if you want to do OctoPrint deve
        #        < ok T0:34.3/0.0 T1:23.5/0.0 B:43.2/0.0
        includeCurrentToolInTemps: true
 
+       # Whether to include the selected filename in the M23 File opened response.
+       #
+       # True:  > M23 filename.gcode
+       #        < File opened: filename.gcode  Size: 27
+       # False: > M23 filename.gcode
+       #        > File opened
+       includeFilenameInOpened: true
+
        # The maximum movement speeds of the simulated printer's axes, in mm/s
        movementSpeed:
          x: 6000

--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -539,7 +539,10 @@ class VirtualPrinter(object):
 		else:
 			self._selectedSdFile = file
 			self._selectedSdFileSize = os.stat(file).st_size
-			self._send("File opened: %s  Size: %d" % (filename, self._selectedSdFileSize))
+			if settings().getBoolean(["devel", "virtualPrinter", "includeFilenameInOpened"]):
+				self._send("File opened: %s  Size: %d" % (filename, self._selectedSdFileSize))
+			else:
+				self._send("File opened")
 			self._send("File selected")
 
 	def _startSdPrint(self):

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -362,7 +362,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
 		self._printAfterSelect = printAfterSelect
 		self._posAfterSelect = pos
-		self._comm.selectFile("/" + path if sd else path, sd)
+		self._comm.selectFile("/" + path if sd and not settings().getBoolean(["feature", "sdRelativePath"]) else path, sd)
 		self._setProgressData(completion=0)
 		self._setCurrentZ(None)
 

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -68,6 +68,7 @@ def getSettings():
 			"alwaysSendChecksum": s.getBoolean(["feature", "alwaysSendChecksum"]),
 			"neverSendChecksum": s.getBoolean(["feature", "neverSendChecksum"]),
 			"sdSupport": s.getBoolean(["feature", "sdSupport"]),
+			"sdRelativePath": s.getBoolean(["feature", "sdRelativePath"]),
 			"sdAlwaysAvailable": s.getBoolean(["feature", "sdAlwaysAvailable"]),
 			"swallowOkAfterResend": s.getBoolean(["feature", "swallowOkAfterResend"]),
 			"repetierTargetTemp": s.getBoolean(["feature", "repetierTargetTemp"]),
@@ -229,6 +230,7 @@ def _saveSettings(data):
 		if "alwaysSendChecksum" in data["feature"].keys(): s.setBoolean(["feature", "alwaysSendChecksum"], data["feature"]["alwaysSendChecksum"])
 		if "neverSendChecksum" in data["feature"].keys(): s.setBoolean(["feature", "neverSendChecksum"], data["feature"]["neverSendChecksum"])
 		if "sdSupport" in data["feature"].keys(): s.setBoolean(["feature", "sdSupport"], data["feature"]["sdSupport"])
+		if "sdRelativePath" in data["feature"].keys(): s.setBoolean(["feature", "sdRelativePath"], data["feature"]["sdRelativePath"])
 		if "sdAlwaysAvailable" in data["feature"].keys(): s.setBoolean(["feature", "sdAlwaysAvailable"], data["feature"]["sdAlwaysAvailable"])
 		if "swallowOkAfterResend" in data["feature"].keys(): s.setBoolean(["feature", "swallowOkAfterResend"], data["feature"]["swallowOkAfterResend"])
 		if "repetierTargetTemp" in data["feature"].keys(): s.setBoolean(["feature", "repetierTargetTemp"], data["feature"]["repetierTargetTemp"])

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -300,6 +300,7 @@ default_settings = {
 			"okWithLinenumber": False,
 			"numExtruders": 1,
 			"includeCurrentToolInTemps": True,
+			"includeFilenameOnOpened": True,
 			"movementSpeed": {
 				"x": 6000,
 				"y": 6000,

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -300,7 +300,7 @@ default_settings = {
 			"okWithLinenumber": False,
 			"numExtruders": 1,
 			"includeCurrentToolInTemps": True,
-			"includeFilenameOnOpened": True,
+			"includeFilenameInOpened": True,
 			"movementSpeed": {
 				"x": 6000,
 				"y": 6000,

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -166,6 +166,7 @@ default_settings = {
 		"sendChecksumWithUnknownCommands": False,
 		"unknownCommandsNeedAck": False,
 		"sdSupport": True,
+		"sdRelativePath": False,
 		"sdAlwaysAvailable": False,
 		"swallowOkAfterResend": True,
 		"repetierTargetTemp": False,

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -124,6 +124,7 @@ $(function() {
         self.feature_waitForStart = ko.observable(undefined);
         self.feature_sendChecksum = ko.observable("print");
         self.feature_sdSupport = ko.observable(undefined);
+        self.feature_sdRelativePath = ko.observable(undefined);
         self.feature_sdAlwaysAvailable = ko.observable(undefined);
         self.feature_swallowOkAfterResend = ko.observable(undefined);
         self.feature_repetierTargetTemp = ko.observable(undefined);

--- a/src/octoprint/templates/dialogs/settings/features.jinja2
+++ b/src/octoprint/templates/dialogs/settings/features.jinja2
@@ -30,6 +30,13 @@
     <div class="control-group">
         <div class="controls">
             <label class="checkbox">
+                <input type="checkbox" data-bind="checked: feature_sdRelativePath" id="settings-sdRelativePath"> {{ _('Select SD files by relative path') }} <span class="label">{{ _('RepRap Firmware') }}</span>
+            </label>
+        </div>
+    </div>
+    <div class="control-group">
+        <div class="controls">
+            <label class="checkbox">
                 <input type="checkbox" data-bind="checked: feature_sdAlwaysAvailable" id="settings-featureSdAlwaysAvailable"> {{ _('Always assume SD card is present') }} <span class="label">{{ _('Repetier') }}</span>
             </label>
         </div>

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -1140,12 +1140,16 @@ class MachineCom(object):
 				elif 'File opened' in line and not self._ignore_select:
 					# answer to M23, at least on Marlin, Repetier and Sprinter: "File opened:%s Size:%d"
 					match = regex_sdFileOpened.search(line)
+					if match:
+						name = match.group("name")
+						size = int(match.group("size"))
+					else:
+						name = "Unknown"
+						size = 0
 					if self._sdFileToSelect:
 						name = self._sdFileToSelect
 						self._sdFileToSelect = None
-					else:
-						name = match.group("name")
-					self._currentFile = PrintingSdFileInformation(name, int(match.group("size")))
+					self._currentFile = PrintingSdFileInformation(name, size)
 				elif 'File selected' in line:
 					if self._ignore_select:
 						self._ignore_select = False


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

It allows firmwares to neglect to respond with the file name for SD card file selection/open
Also, adds an option that causes a relative path to be used for SD file selections

#### How was it tested? How can it be tested by the reviewer?

The PR adds an option to the virtual printer to test the selection responses.  And the UI option sends a different path name.  I tested both using the virtual printer and then a RRF user on the forum tested against an actual printer.

#### Further notes

I did as a PR to make it easier to discuss the proposed changes