### PR TITLE
Added support for  gcode arc commands (G2/G3)  in IJ notation

### DIFF
--- a/src/octoprint/static/gcodeviewer/js/Worker.js
+++ b/src/octoprint/static/gcodeviewer/js/Worker.js
@@ -229,6 +229,7 @@ var doParse = function () {
 
     var layer = 0;
     var x, y, z = 0;
+    var center_i, center_j, direction;
     var prevX = 0, prevY = 0, prevZ = 0;
     var f, lastF = 4000;
     var extrude = false, extrudeRelative = false, retract = 0;
@@ -251,6 +252,9 @@ var doParse = function () {
         y = undefined;
         z = undefined;
         retract = 0;
+        center_i = undefined;
+        center_j = undefined;
+        direction = undefined;
 
         var line = gcode[i].line;
         var percentage = gcode[i].percentage;
@@ -263,7 +267,7 @@ var doParse = function () {
 
         var log = false;
 
-        if (/^(?:G0|G1)\s/i.test(line)) {
+        if (/^(?:G0|G1|G2|G3)\s/i.test(line)) {
             var args = line.split(/\s/);
 
             for (var j = 0; j < args.length; j++) {
@@ -329,6 +333,18 @@ var doParse = function () {
                     case 'f':
                         numSlice = parseFloat(args[j].slice(1));
                         lastF = numSlice;
+                        break;
+                    case 'i':
+                        center_i = Number(args[j].slice(1));
+                        break;
+                    case 'j':
+                        center_j = Number(args[j].slice(1));
+                        break;
+                    case 'g':
+                        if(args[j].charAt(1).toLowerCase()=='2')
+                            direction=1;
+                        if(args[j].charAt(1).toLowerCase()=='3')
+                            direction=-1;
                         break;
                 }
             }
@@ -487,6 +503,9 @@ var doParse = function () {
                 x: x,
                 y: y,
                 z: z,
+                i: center_i,
+                j: center_j,
+                direction: direction,
                 extrude: extrude,
                 retract: retract,
                 noMove: !move,

--- a/src/octoprint/static/gcodeviewer/js/renderer.js
+++ b/src/octoprint/static/gcodeviewer/js/renderer.js
@@ -490,7 +490,19 @@ GCODE.renderer = (function(){
                     ctx.lineWidth = renderOptions['extrusionWidth'];
                     ctx.beginPath();
                     ctx.moveTo(prevX, prevY);
-                    ctx.lineTo(x*zoomFactor,y*zoomFactor);
+                    if(cmd.direction !== undefined && cmd.direction != 0){
+                        var cmd = cmds[i];
+                        var di = cmd.i*zoomFactor;
+                        var dj = -1*cmd.j*zoomFactor; // Y-coordinate is inverted
+                        var centerX = prevX+di;
+                        var centerY = prevY+dj;
+                        var startAngle = Math.atan2(prevY-centerY, prevX - centerX);
+                        var endAngle = Math.atan2(y*zoomFactor-centerY, x*zoomFactor - centerX);
+                        var radius=Math.sqrt(di*di+dj*dj);
+                        ctx.arc(centerX,centerY,radius,startAngle,endAngle,cmd.direction<0); // Y-coordinate is inverted so direction is also inverted
+                    } else {
+                        ctx.lineTo(x*zoomFactor,y*zoomFactor);
+                    }
                     ctx.stroke();
                 } else {
                     // we were previously retracting, now we are restarting => draw dot if configured to do so


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
The patch adds rendering support for G2/G3 codes in the GCode Viewer tab.
#### How was it tested? How can it be tested by the reviewer?
It has been tested by using transformed gcode files loaded into the frontend. These files were created using gcodeutils (https://github.com/zeograd/gcodeutils).
#### Any background context you want to provide?
I extended the gcodeutils to detect and translate cirle segments into arcs (I plan to integrate this as a plugin into OctoPrint). It bothered me that OctoPrint does not show these segments and does wrong time and filament calculations. So easiest was to extend the javascript to do so.
#### What are the relevant tickets if any?
No tickets.
#### Screenshots
Left bottom is a segmented curve while the top right ones are arcs:

<img width="703" alt="gcodeutils-1 3-py2 py3-none-any" src="https://cloud.githubusercontent.com/assets/437271/16236671/79c37e28-37d9-11e6-94a8-d1efde64cdd4.png">

