### PR TITLE
fix intermediary.html for url with parameters

### DIFF
--- a/src/octoprint/static/intermediary.html
+++ b/src/octoprint/static/intermediary.html
@@ -141,14 +141,21 @@
                 var timeout = 1500;
 
                 var baseUrl = window.location.href;
+                var reloadUrl = window.location.href;
                 if (baseUrl.indexOf("#") > -1) {
                     baseUrl = baseUrl.substring(0, baseUrl.indexOf("#"));
+                    reloadUrl = baseUrl;
+                }
+                if (baseUrl.indexOf("?") > -1) {
+                    baseUrl = baseUrl.substring(0, baseUrl.indexOf("?"));
                 }
                 if (baseUrl.indexOf("/static") > -1) {
                     baseUrl = baseUrl.substring(0, baseUrl.indexOf("/static"));
+                    reloadUrl = baseUrl;
                 }
                 if (baseUrl[baseUrl.length - 1] != "/") {
                     baseUrl += "/";
+                    reloadUrl = baseUrl;
                 }
                 var serverOnlineUrl = baseUrl + "online.gif";
                 var backendOnlineUrl = baseUrl + "intermediary.gif";
@@ -164,7 +171,7 @@
                         serverIsOnline = true;
                         message.className = "pulsate1 green";
                         message.innerText = "OctoPrint server online, reloading page...";
-                        window.location = baseUrl;
+                        window.location = reloadUrl;
                     } else {
                         // online.gif still not available, let's look at
                         var interval = 15;


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
handles the OctoPrint startup intermediary.html for UI handling plugins that need parameters

#### How was it tested? How can it be tested by the reviewer?
tested using the "Nautilus" plugin

review test:
`stop octoprint service`
`start octoprint service` and immediately go to `http://your_octoprint_url/?bar=yes&foo=no`
The intermediary.html should load the correct URL preserving the parameters (previously it would give the 'Looks like something went wrong during startup, the server is gone again.' error message)

#### Any background context you want to provide?
The mobile ui provided by a plugin sets a parameter to load the `apikey`

#### What are the relevant tickets if any?
none

#### Screenshots (if appropriate)
none

#### Further notes
none
