### PR TITLE
Typo correction in slicing.rst

### DIFF
--- a/docs/api/slicing.rst
+++ b/docs/api/slicing.rst
@@ -32,7 +32,7 @@ List All Slicers and Slicing Profiles
 
    .. sourcecode:: http
 
-      GET /api/slicing/profiles HTTP/1.1
+      GET /api/slicing HTTP/1.1
       Host: example.com
       X-Api-Key: abcdef...
 


### PR DESCRIPTION
In 'Retrieve all slicing profiles' :
'GET /api/slicing/profiles' -> 'GET /api/slicing'