### PR TITLE
python3: changes exceptions, queue and asesrtEqual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,11 @@ OctoPrint.egg-info
 *.orig
 
 *.codekit
+
+venv
+venv26
+venv27
+venv33
+venv34
+venv35
+venv36

--- a/src/octoprint/events.py
+++ b/src/octoprint/events.py
@@ -8,7 +8,10 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 import datetime
 import logging
 import subprocess
-import Queue
+try:
+	import queue
+except ImportError:
+	import Queue as queue
 import threading
 import collections
 
@@ -120,7 +123,7 @@ class EventManager(object):
 		self._registeredListeners = collections.defaultdict(list)
 		self._logger = logging.getLogger(__name__)
 
-		self._queue = Queue.Queue()
+		self._queue = queue.Queue()
 		self._worker = threading.Thread(target=self._work)
 		self._worker.daemon = True
 		self._worker.start()
@@ -300,7 +303,7 @@ class CommandTrigger(GenericEventListener):
 				else:
 					processedCommand = self._processCommand(command, payload)
 				self.executeCommand(processedCommand, commandType, debug=debug)
-			except KeyError, e:
+			except KeyError as e:
 				self._logger.warn("There was an error processing one or more placeholders in the following command: %s" % command)
 
 	def executeCommand(self, command, commandType, debug=False):
@@ -324,7 +327,7 @@ class CommandTrigger(GenericEventListener):
 					commandExecutioner(c)
 			else:
 				commandExecutioner(command)
-		except subprocess.CalledProcessError, e:
+		except subprocess.CalledProcessError as e:
 			self._logger.warn("Command failed with return code %i: %s" % (e.returncode, str(e)))
 		except:
 			self._logger.exception("Command failed")

--- a/src/octoprint/filemanager/analysis.py
+++ b/src/octoprint/filemanager/analysis.py
@@ -7,7 +7,10 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 
 
 import logging
-import Queue as queue
+try:
+	import queue
+except ImportError:
+	import Queue as queue
 import os
 import threading
 import collections

--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -9,7 +9,10 @@ import os
 import re
 import threading
 import math
-import Queue
+try:
+	import queue
+except ImportError:
+	import Queue as queue
 
 from serial import SerialTimeoutException
 
@@ -42,8 +45,8 @@ class VirtualPrinter(object):
 		self._write_timeout = write_timeout
 
 		self.incoming = CharCountingQueue(settings().getInt(["devel", "virtualPrinter", "rxBuffer"]), name="RxBuffer")
-		self.outgoing = Queue.Queue()
-		self.buffered = Queue.Queue(maxsize=settings().getInt(["devel", "virtualPrinter", "commandBuffer"]))
+		self.outgoing = queue.Queue()
+		self.buffered = queue.Queue(maxsize=settings().getInt(["devel", "virtualPrinter", "commandBuffer"]))
 
 		for item in ['start\n', 'Marlin: Virtual Marlin!\n', '\x80\n', 'SD card ok\n']:
 			self._send(item)
@@ -121,7 +124,7 @@ class VirtualPrinter(object):
 		try:
 			while queue.get(block=False):
 				continue
-		except Queue.Empty:
+		except queue.Empty:
 			pass
 
 	def _processIncoming(self):
@@ -131,7 +134,7 @@ class VirtualPrinter(object):
 
 			try:
 				data = self.incoming.get(timeout=0.01)
-			except Queue.Empty:
+			except queue.Empty:
 				if self._sendWait and time.time() > next_wait_timeout:
 					self._send("wait")
 					next_wait_timeout = time.time() + self._waitInterval
@@ -839,7 +842,7 @@ class VirtualPrinter(object):
 		while self.buffered is not None:
 			try:
 				line = self.buffered.get(timeout=0.5)
-			except Queue.Empty:
+			except queue.Empty:
 				continue
 
 			if line is None:
@@ -865,7 +868,7 @@ class VirtualPrinter(object):
 			try:
 				self.incoming.put(data, timeout=self._write_timeout)
 				self._seriallog.info("<<< {}".format(data.strip()))
-			except Queue.Full:
+			except queue.Full:
 				self._logger.info("Incoming queue is full, raising SerialTimeoutException")
 				raise SerialTimeoutException()
 
@@ -877,7 +880,7 @@ class VirtualPrinter(object):
 			line = self.outgoing.get(timeout=self._read_timeout)
 			self._seriallog.info(">>> {}".format(line.strip()))
 			return line
-		except Queue.Empty:
+		except queue.Empty:
 			return ""
 
 	def close(self):
@@ -904,10 +907,10 @@ class VirtualPrinter(object):
 		if self.outgoing is not None:
 			self.outgoing.put(line)
 
-class CharCountingQueue(Queue.Queue):
+class CharCountingQueue(queue.Queue):
 
 	def __init__(self, maxsize, name=None):
-		Queue.Queue.__init__(self, maxsize=maxsize)
+		queue.Queue.__init__(self, maxsize=maxsize)
 		self._size = 0
 		self._name = name
 
@@ -918,7 +921,7 @@ class CharCountingQueue(Queue.Queue):
 
 			if not block:
 				if self._qsize() + item_size >= self.maxsize:
-					raise Queue.Full
+					raise queue.Full
 			elif timeout is None:
 				while self._qsize() + item_size >= self.maxsize:
 					self.not_full.wait()
@@ -929,7 +932,7 @@ class CharCountingQueue(Queue.Queue):
 				while self._qsize() + item_size >= self.maxsize:
 					remaining = endtime - time.time()
 					if remaining <= 0.0:
-						raise Queue.Full
+						raise queue.Full
 					self.not_full.wait(remaining)
 
 			self._put(item)

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -804,7 +804,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 				"messages": list(self._messages)
 			})
 			callback.on_printer_send_initial_data(data)
-		except Exception, err:
+		except Exception as err:
 			import sys
 			sys.stderr.write("ERROR: %s\n" % str(err))
 			pass

--- a/src/octoprint/server/api/system.py
+++ b/src/octoprint/server/api/system.py
@@ -93,7 +93,7 @@ def executeSystemCommand(source, command):
 				error = "Command failed with return code {}:\nSTDOUT: {}\nSTDERR: {}".format(returncode, stdout_text, stderr_text)
 				logger.warn(error)
 				return make_response(error, 500)
-	except Exception, e:
+	except Exception as e:
 		if not ignore:
 			error = "Command failed: {}".format(str(e))
 			logger.warn(error)

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -11,7 +11,10 @@ import fnmatch
 import datetime
 import sys
 import shutil
-import Queue
+try:
+	import queue
+except ImportError:
+	import Queue as queue
 import requests
 
 import octoprint.util as util
@@ -318,7 +321,7 @@ class Timelapse(object):
 		self._fps = fps
 
 		self._capture_mutex = threading.Lock()
-		self._capture_queue = Queue.Queue()
+		self._capture_queue = queue.Queue()
 		self._capture_queue_active = True
 
 		self._capture_queue_thread = threading.Thread(target=self._capture_queue_worker)

--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -18,7 +18,10 @@ import threading
 from functools import wraps
 import warnings
 import contextlib
-import Queue as queue
+try:
+	import queue
+except ImportError:
+	import Queue as queue
 
 logger = logging.getLogger(__name__)
 

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -10,7 +10,10 @@ import glob
 import time
 import re
 import threading
-import Queue as queue
+try:
+	import queue
+except ImportError:
+	import Queue as queue
 import logging
 import serial
 import octoprint.plugin
@@ -1464,7 +1467,7 @@ class MachineCom(object):
 				self._log("Connecting to: %s" % (p))
 				programmer.connect(p)
 				serial_obj = programmer.leaveISP()
-			except ispBase.IspError as (e):
+			except ispBase.IspError as e:
 				error_message = "Error while connecting to %s: %s" % (p, str(e))
 				self._log(error_message)
 				self._logger.exception(error_message)

--- a/tests/filemanager/test_filemanager.py
+++ b/tests/filemanager/test_filemanager.py
@@ -67,13 +67,13 @@ class FilemanagerMethodTest(unittest.TestCase):
 		self.assertItemsEqual(["amf"], full["model"]["amf"])
 
 	def test_get_mimetype(self):
-		self.assertEquals(octoprint.filemanager.get_mime_type("foo.stl"), "application/sla")
-		self.assertEquals(octoprint.filemanager.get_mime_type("foo.gcode"), "text/plain")
-		self.assertEquals(octoprint.filemanager.get_mime_type("foo.unknown"), "application/octet-stream")
-		self.assertEquals(octoprint.filemanager.get_mime_type("foo.mime_map_yes"), "application/mime_map_yes")
-		self.assertEquals(octoprint.filemanager.get_mime_type("foo.mime_map_no"), "application/octet-stream")
-		self.assertEquals(octoprint.filemanager.get_mime_type("foo.mime_detect_yes"), "application/mime_detect_yes")
-		self.assertEquals(octoprint.filemanager.get_mime_type("foo.mime_detect_no"), "application/octet-stream")
+		self.assertEqual(octoprint.filemanager.get_mime_type("foo.stl"), "application/sla")
+		self.assertEqual(octoprint.filemanager.get_mime_type("foo.gcode"), "text/plain")
+		self.assertEqual(octoprint.filemanager.get_mime_type("foo.unknown"), "application/octet-stream")
+		self.assertEqual(octoprint.filemanager.get_mime_type("foo.mime_map_yes"), "application/mime_map_yes")
+		self.assertEqual(octoprint.filemanager.get_mime_type("foo.mime_map_no"), "application/octet-stream")
+		self.assertEqual(octoprint.filemanager.get_mime_type("foo.mime_detect_yes"), "application/mime_detect_yes")
+		self.assertEqual(octoprint.filemanager.get_mime_type("foo.mime_detect_no"), "application/octet-stream")
 
 	def test_valid_file_type(self):
 		self.assertTrue(octoprint.filemanager.valid_file_type("foo.stl", type="model"))
@@ -87,11 +87,11 @@ class FilemanagerMethodTest(unittest.TestCase):
 		self.assertFalse(octoprint.filemanager.valid_file_type("foo.unknown"))
 
 	def test_get_file_type(self):
-		self.assertEquals(["machinecode", "gcode"], octoprint.filemanager.get_file_type("foo.gcode"))
-		self.assertEquals(["machinecode", "gcode"], octoprint.filemanager.get_file_type("foo.gco"))
-		self.assertEquals(["machinecode", "foo"], octoprint.filemanager.get_file_type("foo.f"))
-		self.assertEquals(["model", "stl"], octoprint.filemanager.get_file_type("foo.stl"))
-		self.assertEquals(["model", "amf"], octoprint.filemanager.get_file_type("foo.amf"))
+		self.assertEqual(["machinecode", "gcode"], octoprint.filemanager.get_file_type("foo.gcode"))
+		self.assertEqual(["machinecode", "gcode"], octoprint.filemanager.get_file_type("foo.gco"))
+		self.assertEqual(["machinecode", "foo"], octoprint.filemanager.get_file_type("foo.f"))
+		self.assertEqual(["model", "stl"], octoprint.filemanager.get_file_type("foo.stl"))
+		self.assertEqual(["model", "amf"], octoprint.filemanager.get_file_type("foo.amf"))
 		self.assertIsNone(octoprint.filemanager.get_file_type("foo.unknown"))
 
 	def test_hook_failure(self):
@@ -105,7 +105,7 @@ class FilemanagerMethodTest(unittest.TestCase):
 
 			octoprint.filemanager.get_all_extensions()
 
-			self.assertEquals(1, len(logger.mock_calls))
+			self.assertEqual(1, len(logger.mock_calls))
 
 class FileManagerTest(unittest.TestCase):
 
@@ -165,7 +165,7 @@ class FileManagerTest(unittest.TestCase):
 
 		file_path = self.file_manager.add_file(octoprint.filemanager.FileDestinations.LOCAL, "test.file", wrapper)
 
-		self.assertEquals(("", "test.file"), file_path)
+		self.assertEqual(("", "test.file"), file_path)
 		self.local_storage.add_file.assert_called_once_with("test.file", wrapper, printer_profile=test_profile, allow_overwrite=False, links=None)
 		self.fire_event.assert_called_once_with(octoprint.filemanager.Events.UPDATED_FILES, dict(type="printables"))
 
@@ -180,7 +180,7 @@ class FileManagerTest(unittest.TestCase):
 
 		folder_path = self.file_manager.add_folder(octoprint.filemanager.FileDestinations.LOCAL, "test_folder")
 
-		self.assertEquals(("", "test_folder"), folder_path)
+		self.assertEqual(("", "test_folder"), folder_path)
 		self.local_storage.add_folder.assert_called_once_with("test_folder", ignore_existing=True)
 		self.fire_event.assert_called_once_with(octoprint.filemanager.Events.UPDATED_FILES, dict(type="printables"))
 
@@ -191,7 +191,7 @@ class FileManagerTest(unittest.TestCase):
 			self.file_manager.add_folder(octoprint.filemanager.FileDestinations.LOCAL, "test_folder", ignore_existing=False)
 			self.fail("Expected an exception to occur!")
 		except RuntimeError as e:
-			self.assertEquals("already there", e.message)
+			self.assertEqual("already there", e.message)
 		self.local_storage.add_folder.assert_called_once_with("test_folder", ignore_existing=False)
 
 	def test_remove_folder(self):
@@ -333,7 +333,7 @@ class FileManagerTest(unittest.TestCase):
 
 		metadata = self.file_manager.get_metadata(octoprint.filemanager.FileDestinations.LOCAL, "test.file")
 
-		self.assertEquals(metadata, expected)
+		self.assertEqual(metadata, expected)
 		self.local_storage.get_metadata.assert_called_once_with("test.file")
 
 	@mock.patch("octoprint.filemanager.util.atomic_write")
@@ -384,9 +384,9 @@ class FileManagerTest(unittest.TestCase):
 
 		# mock slice method on slicing manager
 		def slice(slicer_name, source_path, dest_path, profile, done_cb, printer_profile_id=None, position=None, callback_args=None, overrides=None, on_progress=None, on_progress_args=None, on_progress_kwargs=None):
-			self.assertEquals("some_slicer", slicer_name)
-			self.assertEquals("prefix/source.file", source_path)
-			self.assertEquals("tmp.file", dest_path)
+			self.assertEqual("some_slicer", slicer_name)
+			self.assertEqual("prefix/source.file", source_path)
+			self.assertEqual("tmp.file", dest_path)
 			self.assertIsNone(profile)
 			self.assertIsNone(overrides)
 			self.assertIsNone(printer_profile_id)
@@ -415,15 +415,15 @@ class FileManagerTest(unittest.TestCase):
 
 		# assert that the generated gcode was manipulated as required
 		expected_atomic_write_calls = [mock.call("prefix/dest.file", "wb")]
-		self.assertEquals(mocked_atomic_write.call_args_list, expected_atomic_write_calls)
+		self.assertEqual(mocked_atomic_write.call_args_list, expected_atomic_write_calls)
 		#mocked_open.return_value.write.assert_called_once_with(";Generated from source.file aabbccddeeff\r")
 
 		# assert that shutil was asked to copy the concatenated multistream
-		self.assertEquals(1, len(mocked_shutil.call_args_list))
+		self.assertEqual(1, len(mocked_shutil.call_args_list))
 		shutil_call_args = mocked_shutil.call_args_list[0]
 		self.assertTrue(isinstance(shutil_call_args[0][0], octoprint.filemanager.util.MultiStream))
 		multi_stream = shutil_call_args[0][0]
-		self.assertEquals(2, len(multi_stream.streams))
+		self.assertEqual(2, len(multi_stream.streams))
 		self.assertTrue(isinstance(multi_stream.streams[0], io.BytesIO))
 
 		# assert that the temporary file was deleted
@@ -457,9 +457,9 @@ class FileManagerTest(unittest.TestCase):
 
 		# mock slice method on slicing manager
 		def slice(slicer_name, source_path, dest_path, profile, done_cb, printer_profile_id=None, position=None, callback_args=None, overrides=None, on_progress=None, on_progress_args=None, on_progress_kwargs=None):
-			self.assertEquals("some_slicer", slicer_name)
-			self.assertEquals("prefix/source.file", source_path)
-			self.assertEquals("tmp.file", dest_path)
+			self.assertEqual("some_slicer", slicer_name)
+			self.assertEqual("prefix/source.file", source_path)
+			self.assertEqual("tmp.file", dest_path)
 			self.assertIsNone(profile)
 			self.assertIsNone(overrides)
 			self.assertIsNone(printer_profile_id)

--- a/tests/filemanager/test_localstorage.py
+++ b/tests/filemanager/test_localstorage.py
@@ -88,13 +88,13 @@ class LocalStorageTest(unittest.TestCase):
 		stl_metadata = self.storage.get_metadata(stl_name)
 
 		self.assertIsNotNone(stl_metadata)
-		self.assertEquals(1, len(stl_metadata["links"]))
+		self.assertEqual(1, len(stl_metadata["links"]))
 		link = stl_metadata["links"][0]
 		self.assertTrue("web", link["rel"])
 		self.assertTrue("href" in link)
-		self.assertEquals(href, link["href"])
+		self.assertEqual(href, link["href"])
 		self.assertTrue("retrieved" in link)
-		self.assertEquals(retrieved, link["retrieved"])
+		self.assertEqual(retrieved, link["retrieved"])
 
 	def test_add_file_with_association(self):
 		stl_name = self._add_and_verify_file("bp_case.stl", "bp_case.stl", FILE_BP_CASE_STL)
@@ -104,22 +104,22 @@ class LocalStorageTest(unittest.TestCase):
 		gcode_metadata = self.storage.get_metadata(gcode_name)
 
 		# forward link
-		self.assertEquals(1, len(gcode_metadata["links"]))
+		self.assertEqual(1, len(gcode_metadata["links"]))
 		link = gcode_metadata["links"][0]
-		self.assertEquals("model", link["rel"])
+		self.assertEqual("model", link["rel"])
 		self.assertTrue("name" in link)
-		self.assertEquals(stl_name, link["name"])
+		self.assertEqual(stl_name, link["name"])
 		self.assertTrue("hash" in link)
-		self.assertEquals(FILE_BP_CASE_STL.hash, link["hash"])
+		self.assertEqual(FILE_BP_CASE_STL.hash, link["hash"])
 
 		# reverse link
-		self.assertEquals(1, len(stl_metadata["links"]))
+		self.assertEqual(1, len(stl_metadata["links"]))
 		link = stl_metadata["links"][0]
-		self.assertEquals("machinecode", link["rel"])
+		self.assertEqual("machinecode", link["rel"])
 		self.assertTrue("name" in link)
-		self.assertEquals(gcode_name, link["name"])
+		self.assertEqual(gcode_name, link["name"])
 		self.assertTrue("hash" in link)
-		self.assertEquals(FILE_BP_CASE_GCODE.hash, link["hash"])
+		self.assertEqual(FILE_BP_CASE_GCODE.hash, link["hash"])
 
 	def test_remove_file(self):
 		stl_name = self._add_and_verify_file("bp_case.stl", "bp_case.stl", FILE_BP_CASE_STL)
@@ -140,7 +140,7 @@ class LocalStorageTest(unittest.TestCase):
 		self.assertIsNone(stl_metadata)
 		self.assertIsNotNone(gcode_metadata)
 
-		self.assertEquals(0, len(gcode_metadata["links"]))
+		self.assertEqual(0, len(gcode_metadata["links"]))
 
 	def test_copy_file(self):
 		self._add_file("bp_case.stl", FILE_BP_CASE_STL)
@@ -338,26 +338,26 @@ class LocalStorageTest(unittest.TestCase):
 		self._add_and_verify_folder("empty", "empty")
 
 		file_list = self.storage.list_files()
-		self.assertEquals(4, len(file_list))
+		self.assertEqual(4, len(file_list))
 		self.assertTrue("bp_case.stl" in file_list)
 		self.assertTrue("bp_case.gcode" in file_list)
 		self.assertTrue("content" in file_list)
 		self.assertTrue("empty" in file_list)
 
-		self.assertEquals("model", file_list["bp_case.stl"]["type"])
-		self.assertEquals(FILE_BP_CASE_STL.hash, file_list["bp_case.stl"]["hash"])
+		self.assertEqual("model", file_list["bp_case.stl"]["type"])
+		self.assertEqual(FILE_BP_CASE_STL.hash, file_list["bp_case.stl"]["hash"])
 
-		self.assertEquals("machinecode", file_list["bp_case.gcode"]["type"])
-		self.assertEquals(FILE_BP_CASE_GCODE.hash, file_list["bp_case.gcode"]["hash"])
+		self.assertEqual("machinecode", file_list["bp_case.gcode"]["type"])
+		self.assertEqual(FILE_BP_CASE_GCODE.hash, file_list["bp_case.gcode"]["hash"])
 
-		self.assertEquals("folder", file_list[content_folder]["type"])
-		self.assertEquals(1, len(file_list[content_folder]["children"]))
+		self.assertEqual("folder", file_list[content_folder]["type"])
+		self.assertEqual(1, len(file_list[content_folder]["children"]))
 		self.assertTrue("crazyradio.stl" in file_list["content"]["children"])
-		self.assertEquals("model", file_list["content"]["children"]["crazyradio.stl"]["type"])
-		self.assertEquals(FILE_CRAZYRADIO_STL.hash, file_list["content"]["children"]["crazyradio.stl"]["hash"])
+		self.assertEqual("model", file_list["content"]["children"]["crazyradio.stl"]["type"])
+		self.assertEqual(FILE_CRAZYRADIO_STL.hash, file_list["content"]["children"]["crazyradio.stl"]["hash"])
 
-		self.assertEquals("folder", file_list["empty"]["type"])
-		self.assertEquals(0, len(file_list["empty"]["children"]))
+		self.assertEqual("folder", file_list["empty"]["type"])
+		self.assertEqual(0, len(file_list["empty"]["children"]))
 
 	def test_add_link_model(self):
 		stl_name = self._add_and_verify_file("bp_case.stl", "bp_case.stl", FILE_BP_CASE_STL)
@@ -369,22 +369,22 @@ class LocalStorageTest(unittest.TestCase):
 		gcode_metadata = self.storage.get_metadata(gcode_name)
 
 		# forward link
-		self.assertEquals(1, len(gcode_metadata["links"]))
+		self.assertEqual(1, len(gcode_metadata["links"]))
 		link = gcode_metadata["links"][0]
-		self.assertEquals("model", link["rel"])
+		self.assertEqual("model", link["rel"])
 		self.assertTrue("name" in link)
-		self.assertEquals(stl_name, link["name"])
+		self.assertEqual(stl_name, link["name"])
 		self.assertTrue("hash" in link)
-		self.assertEquals(FILE_BP_CASE_STL.hash, link["hash"])
+		self.assertEqual(FILE_BP_CASE_STL.hash, link["hash"])
 
 		# reverse link
-		self.assertEquals(1, len(stl_metadata["links"]))
+		self.assertEqual(1, len(stl_metadata["links"]))
 		link = stl_metadata["links"][0]
-		self.assertEquals("machinecode", link["rel"])
+		self.assertEqual("machinecode", link["rel"])
 		self.assertTrue("name" in link)
-		self.assertEquals(gcode_name, link["name"])
+		self.assertEqual(gcode_name, link["name"])
 		self.assertTrue("hash" in link)
-		self.assertEquals(FILE_BP_CASE_GCODE.hash, link["hash"])
+		self.assertEqual(FILE_BP_CASE_GCODE.hash, link["hash"])
 
 	def test_add_link_machinecode(self):
 		stl_name = self._add_and_verify_file("bp_case.stl", "bp_case.stl", FILE_BP_CASE_STL)
@@ -396,22 +396,22 @@ class LocalStorageTest(unittest.TestCase):
 		gcode_metadata = self.storage.get_metadata(gcode_name)
 
 		# forward link
-		self.assertEquals(1, len(gcode_metadata["links"]))
+		self.assertEqual(1, len(gcode_metadata["links"]))
 		link = gcode_metadata["links"][0]
-		self.assertEquals("model", link["rel"])
+		self.assertEqual("model", link["rel"])
 		self.assertTrue("name" in link)
-		self.assertEquals(stl_name, link["name"])
+		self.assertEqual(stl_name, link["name"])
 		self.assertTrue("hash" in link)
-		self.assertEquals(FILE_BP_CASE_STL.hash, link["hash"])
+		self.assertEqual(FILE_BP_CASE_STL.hash, link["hash"])
 
 		# reverse link
-		self.assertEquals(1, len(stl_metadata["links"]))
+		self.assertEqual(1, len(stl_metadata["links"]))
 		link = stl_metadata["links"][0]
-		self.assertEquals("machinecode", link["rel"])
+		self.assertEqual("machinecode", link["rel"])
 		self.assertTrue("name" in link)
-		self.assertEquals(gcode_name, link["name"])
+		self.assertEqual(gcode_name, link["name"])
 		self.assertTrue("hash" in link)
-		self.assertEquals(FILE_BP_CASE_GCODE.hash, link["hash"])
+		self.assertEqual(FILE_BP_CASE_GCODE.hash, link["hash"])
 
 	def test_remove_link(self):
 		stl_name = self._add_and_verify_file("bp_case.stl", "bp_case.stl", FILE_BP_CASE_STL)
@@ -420,17 +420,17 @@ class LocalStorageTest(unittest.TestCase):
 		self.storage.add_link(stl_name, "web", dict(href="http://www.example2.com"))
 
 		stl_metadata = self.storage.get_metadata(stl_name)
-		self.assertEquals(2, len(stl_metadata["links"]))
+		self.assertEqual(2, len(stl_metadata["links"]))
 
 		self.storage.remove_link(stl_name, "web", dict(href="http://www.example.com"))
 
 		stl_metadata = self.storage.get_metadata(stl_name)
-		self.assertEquals(1, len(stl_metadata["links"]))
+		self.assertEqual(1, len(stl_metadata["links"]))
 
 		self.storage.remove_link(stl_name, "web", dict(href="wrong_href"))
 
 		stl_metadata = self.storage.get_metadata(stl_name)
-		self.assertEquals(1, len(stl_metadata["links"]))
+		self.assertEqual(1, len(stl_metadata["links"]))
 
 	def test_remove_link_bidirectional(self):
 		stl_name = self._add_and_verify_file("bp_case.stl", "bp_case.stl", FILE_BP_CASE_STL)
@@ -442,16 +442,16 @@ class LocalStorageTest(unittest.TestCase):
 		stl_metadata = self.storage.get_metadata(stl_name)
 		gcode_metadata = self.storage.get_metadata(gcode_name)
 
-		self.assertEquals(1, len(gcode_metadata["links"]))
-		self.assertEquals(2, len(stl_metadata["links"]))
+		self.assertEqual(1, len(gcode_metadata["links"]))
+		self.assertEqual(2, len(stl_metadata["links"]))
 
 		self.storage.remove_link(gcode_name, "model", dict(name=stl_name, hash=FILE_BP_CASE_STL.hash))
 
 		stl_metadata = self.storage.get_metadata(stl_name)
 		gcode_metadata = self.storage.get_metadata(gcode_name)
 
-		self.assertEquals(0, len(gcode_metadata["links"]))
-		self.assertEquals(1, len(stl_metadata["links"]))
+		self.assertEqual(0, len(gcode_metadata["links"]))
+		self.assertEqual(1, len(stl_metadata["links"]))
 
 	@data(
 		("some_file.gco", "some_file.gco"),
@@ -461,7 +461,7 @@ class LocalStorageTest(unittest.TestCase):
 	@unpack
 	def test_sanitize_name(self, input, expected):
 		actual = self.storage.sanitize_name(input)
-		self.assertEquals(expected, actual)
+		self.assertEqual(expected, actual)
 
 	@data(
 		"some/folder/still/left.gco",
@@ -472,7 +472,7 @@ class LocalStorageTest(unittest.TestCase):
 			self.storage.sanitize_name(input)
 			self.fail("expected a ValueError")
 		except ValueError as e:
-			self.assertEquals("name must not contain / or \\", e.message)
+			self.assertEqual("name must not contain / or \\", e.message)
 
 	@data(
 		("folder/with/subfolder", "/folder/with/subfolder"),
@@ -484,7 +484,7 @@ class LocalStorageTest(unittest.TestCase):
 	def test_sanitize_path(self, input, expected):
 		actual = self.storage.sanitize_path(input)
 		self.assertTrue(actual.startswith(self.basefolder))
-		self.assertEquals(expected, actual[len(self.basefolder):].replace(os.path.sep, "/"))
+		self.assertEqual(expected, actual[len(self.basefolder):].replace(os.path.sep, "/"))
 
 	@data(
 		"../../folder/out/of/the/basefolder",
@@ -510,7 +510,7 @@ class LocalStorageTest(unittest.TestCase):
 	def test_sanitize(self, input, expected_path, expected_name):
 		actual = self.storage.sanitize(input)
 		self.assertTrue(isinstance(actual, tuple))
-		self.assertEquals(2, len(actual))
+		self.assertEqual(2, len(actual))
 
 		actual_path, actual_name = actual
 		self.assertTrue(actual_path.startswith(self.basefolder))
@@ -521,13 +521,13 @@ class LocalStorageTest(unittest.TestCase):
 			# other preprocessing of our test data here
 			actual_path = "/" + actual_path
 
-		self.assertEquals(expected_path, actual_path)
-		self.assertEquals(expected_name, actual_name)
+		self.assertEqual(expected_path, actual_path)
+		self.assertEqual(expected_name, actual_name)
 
 	def _add_and_verify_file(self, path, expected_path, file_object, links=None, overwrite=False):
 		"""Adds a file to the storage and verifies the sanitized path."""
 		sanitized_path = self._add_file(path, file_object, links=links, overwrite=overwrite)
-		self.assertEquals(expected_path, sanitized_path)
+		self.assertEqual(expected_path, sanitized_path)
 		return sanitized_path
 
 	def _add_file(self, path, file_object, links=None, overwrite=False):
@@ -557,7 +557,7 @@ class LocalStorageTest(unittest.TestCase):
 
 		# assert hash
 		self.assertTrue("hash" in metadata)
-		self.assertEquals(file_object.hash, metadata["hash"])
+		self.assertEqual(file_object.hash, metadata["hash"])
 
 		# assert presence of links if supplied
 		if links:
@@ -568,7 +568,7 @@ class LocalStorageTest(unittest.TestCase):
 	def _add_and_verify_folder(self, path, expected_path):
 		"""Adds a folder to the storage and verifies sanitized path."""
 		sanitized_path = self._add_folder(path)
-		self.assertEquals(expected_path, sanitized_path)
+		self.assertEqual(expected_path, sanitized_path)
 		return sanitized_path
 
 	def _add_folder(self, path):

--- a/tests/plugin/test_core.py
+++ b/tests/plugin/test_core.py
@@ -30,30 +30,30 @@ class PluginTestCase(unittest.TestCase):
 		self.plugin_manager.initialize_implementations()
 
 	def test_plugin_loading(self):
-		self.assertEquals(7, len(self.plugin_manager.enabled_plugins))
-		self.assertEquals(2, len(self.plugin_manager.plugin_hooks))
-		self.assertEquals(4, len(self.plugin_manager.plugin_implementations))
-		self.assertEquals(3, len(self.plugin_manager.plugin_implementations_by_type))
+		self.assertEqual(7, len(self.plugin_manager.enabled_plugins))
+		self.assertEqual(2, len(self.plugin_manager.plugin_hooks))
+		self.assertEqual(4, len(self.plugin_manager.plugin_implementations))
+		self.assertEqual(3, len(self.plugin_manager.plugin_implementations_by_type))
 
 		# hook_plugin
 		self.assertTrue("octoprint.core.startup" in self.plugin_manager.plugin_hooks)
-		self.assertEquals(1, len(self.plugin_manager.plugin_hooks["octoprint.core.startup"]))
+		self.assertEqual(1, len(self.plugin_manager.plugin_hooks["octoprint.core.startup"]))
 
 		# ordered hook plugins
 		self.assertTrue("some.ordered.callback" in self.plugin_manager.plugin_hooks)
-		self.assertEquals(3, len(self.plugin_manager.plugin_hooks["some.ordered.callback"]))
+		self.assertEqual(3, len(self.plugin_manager.plugin_hooks["some.ordered.callback"]))
 
 		# TestStartupPlugin & TestMixedPlugin
 		self.assertTrue(octoprint.plugin.StartupPlugin in self.plugin_manager.plugin_implementations_by_type)
-		self.assertEquals(2, len(self.plugin_manager.plugin_implementations_by_type[octoprint.plugin.StartupPlugin]))
+		self.assertEqual(2, len(self.plugin_manager.plugin_implementations_by_type[octoprint.plugin.StartupPlugin]))
 
 		# TestSettingsPlugin & TestMixedPlugin
 		self.assertTrue(octoprint.plugin.SettingsPlugin in self.plugin_manager.plugin_implementations_by_type)
-		self.assertEquals(2, len(self.plugin_manager.plugin_implementations_by_type[octoprint.plugin.SettingsPlugin]))
+		self.assertEqual(2, len(self.plugin_manager.plugin_implementations_by_type[octoprint.plugin.SettingsPlugin]))
 
 		# TestDeprecatedAssetPlugin, NOT TestSecondaryDeprecatedAssetPlugin
 		self.assertTrue(octoprint.plugin.AssetPlugin in self.plugin_manager.plugin_implementations_by_type)
-		self.assertEquals(1, len(self.plugin_manager.plugin_implementations_by_type[octoprint.plugin.AssetPlugin]))
+		self.assertEqual(1, len(self.plugin_manager.plugin_implementations_by_type[octoprint.plugin.AssetPlugin]))
 
 	def test_plugin_initializing(self):
 
@@ -74,41 +74,41 @@ class PluginTestCase(unittest.TestCase):
 		)
 
 		all_implementations = self.plugin_manager.plugin_implementations
-		self.assertEquals(4, len(all_implementations))
+		self.assertEqual(4, len(all_implementations))
 		for name, impl in all_implementations.items():
 			self.assertTrue(name in self.plugin_manager.enabled_plugins)
 			plugin = self.plugin_manager.enabled_plugins[name]
 
 			# test that the standard fields were properly initialized
 			self.assertTrue(hasattr(impl, "_identifier"))
-			self.assertEquals(name, impl._identifier)
+			self.assertEqual(name, impl._identifier)
 			self.assertTrue(hasattr(impl, "_plugin_name"))
-			self.assertEquals(plugin.name, impl._plugin_name)
+			self.assertEqual(plugin.name, impl._plugin_name)
 			self.assertTrue(hasattr(impl, "_plugin_version"))
-			self.assertEquals(plugin.version, impl._plugin_version)
+			self.assertEqual(plugin.version, impl._plugin_version)
 			self.assertTrue(hasattr(impl, "_logger"))
 			self.assertIsNotNone(impl._logger)
-			self.assertEquals("logging_prefix.%s" % name, impl._logger.name)
+			self.assertEqual("logging_prefix.%s" % name, impl._logger.name)
 			self.assertTrue(hasattr(impl, "_basefolder"))
 			self.assertTrue(impl._basefolder.startswith(self.plugin_folder))
 
 			# test that the additional injects were properly injected
 			self.assertTrue(hasattr(impl, "_additional_inject"))
-			self.assertEquals("additional_inject", impl._additional_inject)
+			self.assertEqual("additional_inject", impl._additional_inject)
 
 			# test that the injection factory was properly executed and the result injected
 			self.assertTrue(hasattr(impl, "_test_factory"))
-			self.assertEquals("test_factory_%s" % name, impl._test_factory)
+			self.assertEqual("test_factory_%s" % name, impl._test_factory)
 
 
 	def test_get_plugin(self):
 		plugin = self.plugin_manager.get_plugin("hook_plugin")
 		self.assertIsNotNone(plugin)
-		self.assertEquals("Hook Plugin", plugin.__plugin_name__)
+		self.assertEqual("Hook Plugin", plugin.__plugin_name__)
 
 		plugin = self.plugin_manager.get_plugin("mixed_plugin")
 		self.assertIsNotNone(plugin)
-		self.assertEquals("Mixed Plugin", plugin.__plugin_name__)
+		self.assertEqual("Mixed Plugin", plugin.__plugin_name__)
 
 		plugin = self.plugin_manager.get_plugin("unknown_plugin")
 		self.assertIsNone(plugin)
@@ -116,23 +116,23 @@ class PluginTestCase(unittest.TestCase):
 	def test_get_plugin_info(self):
 		plugin_info = self.plugin_manager.get_plugin_info("hook_plugin")
 		self.assertIsNotNone(plugin_info)
-		self.assertEquals("Hook Plugin", plugin_info.name)
+		self.assertEqual("Hook Plugin", plugin_info.name)
 
 		plugin_info = self.plugin_manager.get_plugin_info("unknown_plugin")
 		self.assertIsNone(plugin_info)
 
 	def test_get_hooks(self):
 		hooks = self.plugin_manager.get_hooks("octoprint.core.startup")
-		self.assertEquals(1, len(hooks))
+		self.assertEqual(1, len(hooks))
 		self.assertTrue("hook_plugin" in hooks)
-		self.assertEquals("success", hooks["hook_plugin"]())
+		self.assertEqual("success", hooks["hook_plugin"]())
 
 		hooks = self.plugin_manager.get_hooks("octoprint.printing.print")
-		self.assertEquals(0, len(hooks))
+		self.assertEqual(0, len(hooks))
 
 	def test_sorted_hooks(self):
 		hooks = self.plugin_manager.get_hooks("some.ordered.callback")
-		self.assertEquals(3, len(hooks))
+		self.assertEqual(3, len(hooks))
 		self.assertListEqual(["one_ordered_hook_plugin", "another_ordered_hook_plugin", "hook_plugin"], hooks.keys())
 
 	def test_get_implementations(self):
@@ -150,7 +150,7 @@ class PluginTestCase(unittest.TestCase):
 
 	def test_get_filtered_implementations(self):
 		implementations = self.plugin_manager.get_filtered_implementations(lambda x: x._identifier.startswith("startup"), octoprint.plugin.StartupPlugin)
-		self.assertEquals(1, len(implementations))
+		self.assertEqual(1, len(implementations))
 
 	def test_get_sorted_implementations(self):
 		implementations = self.plugin_manager.get_implementations(octoprint.plugin.StartupPlugin, sorting_context="sorting_test")
@@ -160,16 +160,16 @@ class PluginTestCase(unittest.TestCase):
 		def test_client(*args, **kwargs):
 			pass
 
-		self.assertEquals(0, len(self.plugin_manager.registered_clients))
+		self.assertEqual(0, len(self.plugin_manager.registered_clients))
 
 		self.plugin_manager.register_message_receiver(test_client)
 
-		self.assertEquals(1, len(self.plugin_manager.registered_clients))
+		self.assertEqual(1, len(self.plugin_manager.registered_clients))
 		self.assertIn(test_client, self.plugin_manager.registered_clients)
 
 		self.plugin_manager.unregister_message_receiver(test_client)
 
-		self.assertEquals(0, len(self.plugin_manager.registered_clients))
+		self.assertEqual(0, len(self.plugin_manager.registered_clients))
 		self.assertNotIn(test_client, self.plugin_manager.registered_clients)
 
 	def test_send_plugin_message(self):

--- a/tests/plugin/test_settings.py
+++ b/tests/plugin/test_settings.py
@@ -112,7 +112,7 @@ class SettingsTestCase(unittest.TestCase):
 
 			called_method.assert_called_once_with(["plugins", self.plugin_key, "some_raw_key"], defaults=dict(plugins=dict(test_plugin=self.defaults)), preprocessors=dict(plugins=dict(test_plugin=self.get_preprocessors)))
 
-			self.assertEquals(1, len(w))
+			self.assertEqual(1, len(w))
 			self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 			self.assertTrue("{old} has been renamed to {new}".format(old=deprecated, new=current) in (w[-1].message))
 
@@ -134,7 +134,7 @@ class SettingsTestCase(unittest.TestCase):
 
 			called_method.assert_called_once_with(["some_raw_key",])
 
-			self.assertEquals(1, len(w))
+			self.assertEqual(1, len(w))
 			self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 			self.assertTrue("{old} has been renamed to {new}".format(old=deprecated, new=current) in (w[-1].message))
 
@@ -198,7 +198,7 @@ class SettingsTestCase(unittest.TestCase):
 
 			called_method.assert_called_once_with(["plugins", self.plugin_key, "some_raw_key"], value, defaults=dict(plugins=dict(test_plugin=self.defaults)), preprocessors=dict(plugins=dict(test_plugin=self.set_preprocessors)))
 
-			self.assertEquals(1, len(w))
+			self.assertEqual(1, len(w))
 			self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 			self.assertTrue("{old} has been renamed to {new}".format(old=deprecated, new=current) in (w[-1].message))
 
@@ -220,7 +220,7 @@ class SettingsTestCase(unittest.TestCase):
 
 			called_method.assert_called_once_with(["some_raw_key"], value)
 
-			self.assertEquals(1, len(w))
+			self.assertEqual(1, len(w))
 			self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 			self.assertTrue("{old} has been renamed to {new}".format(old=deprecated, new=current) in (w[-1].message))
 
@@ -233,7 +233,7 @@ class SettingsTestCase(unittest.TestCase):
 			self.plugin_settings.globalGetBaseFolder("some_folder")
 			self.settings.getBaseFolder.assert_called_once_with("some_folder")
 
-			self.assertEquals(1, len(w))
+			self.assertEqual(1, len(w))
 			self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 			self.assertTrue("globalGetBaseFolder has been renamed to global_get_basefolder" in (w[-1].message))
 
@@ -245,7 +245,7 @@ class SettingsTestCase(unittest.TestCase):
 		path = self.plugin_settings.get_plugin_logfile_path()
 
 		self.settings.getBaseFolder.assert_called_once_with("logs")
-		self.assertEquals("/some/folder/plugin_{key}.log".format(key=self.plugin_key), path.replace(os.sep, "/"))
+		self.assertEqual("/some/folder/plugin_{key}.log".format(key=self.plugin_key), path.replace(os.sep, "/"))
 
 	def test_logfile_path_with_postfix(self):
 		import os
@@ -255,7 +255,7 @@ class SettingsTestCase(unittest.TestCase):
 		path = self.plugin_settings.get_plugin_logfile_path(postfix="mypostfix")
 
 		self.settings.getBaseFolder.assert_called_once_with("logs")
-		self.assertEquals("/some/folder/plugin_{key}_mypostfix.log".format(key=self.plugin_key), path.replace(os.sep, "/"))
+		self.assertEqual("/some/folder/plugin_{key}_mypostfix.log".format(key=self.plugin_key), path.replace(os.sep, "/"))
 
 	def test_deprecated_logfile_path(self):
 		import os
@@ -265,9 +265,9 @@ class SettingsTestCase(unittest.TestCase):
 			path = self.plugin_settings.getPluginLogfilePath()
 
 			self.settings.getBaseFolder.assert_called_once_with("logs")
-			self.assertEquals("/some/folder/plugin_{key}.log".format(key=self.plugin_key), path.replace(os.sep, "/"))
+			self.assertEqual("/some/folder/plugin_{key}.log".format(key=self.plugin_key), path.replace(os.sep, "/"))
 
-			self.assertEquals(1, len(w))
+			self.assertEqual(1, len(w))
 			self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 			self.assertTrue("getPluginLogfilePath has been renamed to get_plugin_logfile_path" in (w[-1].message))
 

--- a/tests/plugin/test_types_blueprint.py
+++ b/tests/plugin/test_types_blueprint.py
@@ -64,7 +64,7 @@ class BlueprintPluginTest(unittest.TestCase):
 
 		result = self.plugin.get_blueprint_kwargs()
 
-		self.assertEquals(result, expected)
+		self.assertEqual(result, expected)
 
 	def test_get_blueprint_kwargs_assetplugin(self):
 		import os
@@ -75,7 +75,7 @@ class BlueprintPluginTest(unittest.TestCase):
 
 		result = self.assetplugin.get_blueprint_kwargs()
 
-		self.assertEquals(result, expected)
+		self.assertEqual(result, expected)
 
 	def test_get_blueprint_kwargs_templateplugin(self):
 		import os
@@ -86,7 +86,7 @@ class BlueprintPluginTest(unittest.TestCase):
 
 		result = self.templateplugin.get_blueprint_kwargs()
 
-		self.assertEquals(result, expected)
+		self.assertEqual(result, expected)
 
 	def test_get_blueprint(self):
 		import os
@@ -122,7 +122,7 @@ class BlueprintPluginTest(unittest.TestCase):
 
 			result = plugin.get_blueprint()
 
-		self.assertEquals(result, blueprint)
+		self.assertEqual(result, blueprint)
 
 		MockBlueprint.assert_called_once_with("plugin.myplugin", "myplugin", **expected_kwargs)
 		blueprint.add_url_rule.assert_called_once_with("/some/path", "route_method", view_func=plugin.route_method, methods=["GET"])
@@ -136,4 +136,4 @@ class BlueprintPluginTest(unittest.TestCase):
 
 		result = self.plugin.get_blueprint()
 
-		self.assertEquals(blueprint, result)
+		self.assertEqual(blueprint, result)

--- a/tests/plugin/test_types_settings.py
+++ b/tests/plugin/test_types_settings.py
@@ -219,7 +219,7 @@ class TestSettingsPlugin(unittest.TestCase):
 		)
 		self.settings.set.assert_called_once_with([], expected)
 
-		self.assertEquals(diff, expected)
+		self.assertEqual(diff, expected)
 
 	def test_on_settings_save_nodiff(self):
 		"""Tests that data is cleaned if there's not difference between data and defaults."""
@@ -247,7 +247,7 @@ class TestSettingsPlugin(unittest.TestCase):
 		### assert
 
 		self.settings.clean_all_data.assert_called_once_with()
-		self.assertEquals(diff, dict())
+		self.assertEqual(diff, dict())
 
 	def test_on_settings_save_configversion(self):
 		"""Tests that saved data gets stripped config version and set correct one."""
@@ -279,7 +279,7 @@ class TestSettingsPlugin(unittest.TestCase):
 		# while there was no diff, we should still have saved the new config version
 		self.settings.set.assert_called_once_with([], expected_set)
 
-		self.assertEquals(diff, expected_diff)
+		self.assertEqual(diff, expected_diff)
 
 	def test_on_settings_load(self):
 		"""Tests that on_settings_load returns what's stored in the config, without config version."""
@@ -310,4 +310,4 @@ class TestSettingsPlugin(unittest.TestCase):
 
 		### assert
 
-		self.assertEquals(result, expected)
+		self.assertEqual(result, expected)

--- a/tests/printer/test_estimation.py
+++ b/tests/printer/test_estimation.py
@@ -32,7 +32,7 @@ class EstimationTestCase(unittest.TestCase):
 		for estimate in estimates:
 			self.estimation_helper.update(estimate)
 
-		self.assertEquals(self.estimation_helper.average_total, expected)
+		self.assertEqual(self.estimation_helper.average_total, expected)
 
 	@data(
 		((1.0, 2.0), None),                    # not enough values, have 1, need 3
@@ -46,7 +46,7 @@ class EstimationTestCase(unittest.TestCase):
 		for estimate in estimates:
 			self.estimation_helper.update(estimate)
 
-		self.assertEquals(self.estimation_helper.average_distance, expected)
+		self.assertEqual(self.estimation_helper.average_distance, expected)
 
 	@data(
 		((1.0, 1.0), None),
@@ -58,7 +58,7 @@ class EstimationTestCase(unittest.TestCase):
 		for estimate in estimates:
 			self.estimation_helper.update(estimate)
 
-		self.assertEquals(self.estimation_helper.average_total_rolling, expected)
+		self.assertEqual(self.estimation_helper.average_total_rolling, expected)
 
 	@data(
 		((1.0, 1.0, 1.0, 1.0), False),         # average totals: 1.0, 1.0, 1.0, 1.0 => 3.0 / 3 = 1.0
@@ -71,5 +71,5 @@ class EstimationTestCase(unittest.TestCase):
 		for estimate in estimates:
 			self.estimation_helper.update(estimate)
 
-		self.assertEquals(self.estimation_helper.is_stable(), expected)
+		self.assertEqual(self.estimation_helper.is_stable(), expected)
 

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -66,7 +66,7 @@ class TestSettings(unittest.TestCase):
 			                         (timelapse_folder, expected_timelapse_folder),
 			                         (timelapse_tmp_folder, expected_timelapse_tmp_folder)):
 				self.assertIsNotNone(folder)
-				self.assertEquals(folder, expected)
+				self.assertEqual(folder, expected)
 				self.assertTrue(os.path.isdir(folder))
 
 	def test_basedir_initialization_with_custom_basedir(self):

--- a/tests/slicing/test_slicingmanager.py
+++ b/tests/slicing/test_slicingmanager.py
@@ -55,7 +55,7 @@ class TestSlicingManager(unittest.TestCase):
 		self.plugin_manager.return_value.get_implementations.side_effect = get_implementations
 
 	def test_registered_slicers(self):
-		self.assertEquals(["mock"], self.slicing_manager.registered_slicers)
+		self.assertEqual(["mock"], self.slicing_manager.registered_slicers)
 
 	def test_slicing_enabled(self):
 		self.assertTrue(self.slicing_manager.slicing_enabled)
@@ -68,7 +68,7 @@ class TestSlicingManager(unittest.TestCase):
 				return None
 		self.settings.get.side_effect = get
 
-		self.assertEquals("mock", self.slicing_manager.default_slicer)
+		self.assertEqual("mock", self.slicing_manager.default_slicer)
 
 	def test_default_slicer_unknown(self):
 		def get(path):
@@ -122,7 +122,7 @@ class TestSlicingManager(unittest.TestCase):
 		# mock printer profile manager
 		printer_profile = dict(_id="mock_printer", _name="Mock Printer Profile")
 		def get_printer_profile(printer_profile_id):
-			self.assertEquals("mock_printer", printer_profile_id)
+			self.assertEqual("mock_printer", printer_profile_id)
 			return printer_profile
 		self.printer_profile_manager.get.side_effect = get_printer_profile
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -71,7 +71,7 @@ class DaemonTest(unittest.TestCase):
 		# assert
 		self.assertListEqual(mock_fork.mock_calls, [mock.call()])
 		self.assertListEqual(mock_exit.mock_calls, [mock.call(1)])
-		self.assertEquals(len(self.error_method.mock_calls), 1)
+		self.assertEqual(len(self.error_method.mock_calls), 1)
 
 	@mock.patch("os.fork", create=True)
 	@mock.patch("os.chdir")
@@ -91,9 +91,9 @@ class DaemonTest(unittest.TestCase):
 			pass
 
 		# assert
-		self.assertEquals(mock_fork.call_count, 2)
+		self.assertEqual(mock_fork.call_count, 2)
 		self.assertListEqual(mock_exit.mock_calls, [mock.call(0), mock.call(1)])
-		self.assertEquals(self.error_method.call_count, 1)
+		self.assertEqual(self.error_method.call_count, 1)
 		mock_chdir.assert_called_once_with("/")
 		mock_setsid.assert_called_once_with()
 		mock_umask.assert_called_once_with(002)
@@ -243,7 +243,7 @@ class DaemonTest(unittest.TestCase):
 
 		# assert
 		self.daemon.get_pid.assert_called_once_with()
-		self.assertEquals(self.error_method.call_count, 1)
+		self.assertEqual(self.error_method.call_count, 1)
 		mock_exit.assert_called_once_with(1)
 
 	@mock.patch("sys.exit")
@@ -394,7 +394,7 @@ class DaemonTest(unittest.TestCase):
 			result = self.daemon.get_pid()
 
 		# assert
-		self.assertEquals(result, pid)
+		self.assertEqual(result, pid)
 		m.assert_called_once_with(self.pidfile, "r")
 
 	def test_get_pid_ioerror(self):

--- a/tests/users/__init__.py
+++ b/tests/users/__init__.py
@@ -56,7 +56,7 @@ class UserTestCase(unittest.TestCase):
 	@ddt.unpack
 	def test_get_setting(self, key, expected):
 		value = self.user.get_setting(key)
-		self.assertEquals(expected, value)
+		self.assertEqual(expected, value)
 
 	@ddt.data(
 		("otherkey", "othervalue", dict(otherkey="othervalue"), True),
@@ -109,4 +109,4 @@ class SessionUserTestCase(unittest.TestCase):
 	def test_repr(self):
 		user = octoprint.users.SessionUser(self.user)
 		expected = "SessionUser(id=username,name=username,active=True,user=True,admin=False,session={},created={})".format(user._session, user._created)
-		self.assertEquals(expected, repr(user))
+		self.assertEqual(expected, repr(user))

--- a/tests/util/test_comm_helpers.py
+++ b/tests/util/test_comm_helpers.py
@@ -23,7 +23,7 @@ class TestCommHelpers(unittest.TestCase):
 	@unpack
 	def test_strip_comment(self, input, expected):
 		from octoprint.util import comm
-		self.assertEquals(expected, comm.strip_comment(input))
+		self.assertEqual(expected, comm.strip_comment(input))
 
 	@data(
 		("M117 Test", None, None, "M117 Test"),
@@ -34,7 +34,7 @@ class TestCommHelpers(unittest.TestCase):
 	@unpack
 	def test_process_gcode_line(self, input, offsets, current_tool, expected):
 		from octoprint.util import comm
-		self.assertEquals(expected, comm.process_gcode_line(input, offsets=offsets, current_tool=current_tool))
+		self.assertEqual(expected, comm.process_gcode_line(input, offsets=offsets, current_tool=current_tool))
 
 	@data(
 		("M104 S200", None, None, None),
@@ -58,16 +58,16 @@ class TestCommHelpers(unittest.TestCase):
 		actual = comm.apply_temperature_offsets(input, offsets, current_tool=current_tool)
 
 		if expected is None:
-			self.assertEquals(input, actual)
+			self.assertEqual(input, actual)
 		else:
 			import re
 			match = re.search("S(\d+(\.\d+)?)", actual)
 			if not match:
 				self.fail("No temperature found")
 			temperature = float(match.group(1))
-			self.assertEquals(expected, temperature)
-			self.assertEquals(input[:match.start(1)], actual[:match.start(1)])
-			self.assertEquals(input[match.end(1):], actual[match.end(1):])
+			self.assertEqual(expected, temperature)
+			self.assertEqual(input[:match.start(1)], actual[:match.start(1)])
+			self.assertEqual(input[match.end(1):], actual[match.end(1):])
 
 	def test_convert_pause_triggers(self):
 		configured_triggers = [
@@ -86,13 +86,13 @@ class TestCommHelpers(unittest.TestCase):
 		self.assertIsNotNone(trigger_matchers)
 
 		self.assertIn("enable", trigger_matchers)
-		self.assertEquals("(pause1)|(pause2)", trigger_matchers["enable"].pattern)
+		self.assertEqual("(pause1)|(pause2)", trigger_matchers["enable"].pattern)
 
 		self.assertIn("disable", trigger_matchers)
-		self.assertEquals("(resume)", trigger_matchers["disable"].pattern)
+		self.assertEqual("(resume)", trigger_matchers["disable"].pattern)
 
 		self.assertIn("toggle", trigger_matchers)
-		self.assertEquals("(toggle)", trigger_matchers["toggle"].pattern)
+		self.assertEqual("(toggle)", trigger_matchers["toggle"].pattern)
 
 		self.assertNotIn("unknown", trigger_matchers)
 
@@ -127,35 +127,35 @@ class TestCommHelpers(unittest.TestCase):
 		from octoprint.util import comm
 		controls, matcher = comm.convert_feedback_controls(configured_controls)
 
-		self.assertEquals(2, len(controls))
+		self.assertEqual(2, len(controls))
 
 		# temp_regex is used twice, so we should have two templates for it
 		self.assertIn(temp_key, controls)
 		temp = controls[temp_key]
 
 		self.assertIsNotNone(temp["matcher"])
-		self.assertEquals(temp_regex, temp["matcher"].pattern)
-		self.assertEquals(temp_regex, temp["pattern"])
+		self.assertEqual(temp_regex, temp["matcher"].pattern)
+		self.assertEqual(temp_regex, temp["pattern"])
 
-		self.assertEquals(2, len(temp["templates"]))
+		self.assertEqual(2, len(temp["templates"]))
 		self.assertIn(temp_template_key, temp["templates"])
-		self.assertEquals(temp_template, temp["templates"][temp_template_key])
+		self.assertEqual(temp_template, temp["templates"][temp_template_key])
 		self.assertIn(temp2_template_key, temp["templates"])
-		self.assertEquals(temp2_template, temp["templates"][temp2_template_key])
+		self.assertEqual(temp2_template, temp["templates"][temp2_template_key])
 
 		# x_regex is used once, so we should have only one template for it
 		self.assertIn(x_key, controls)
 		x = controls[x_key]
 
 		self.assertIsNotNone(x["matcher"])
-		self.assertEquals(x_regex, x["matcher"].pattern)
-		self.assertEquals(x_regex, x["pattern"])
+		self.assertEqual(x_regex, x["matcher"].pattern)
+		self.assertEqual(x_regex, x["pattern"])
 
-		self.assertEquals(1, len(x["templates"]))
+		self.assertEqual(1, len(x["templates"]))
 		self.assertIn(x_template_key, x["templates"])
-		self.assertEquals(x_template, x["templates"][x_template_key])
+		self.assertEqual(x_template, x["templates"][x_template_key])
 
-		self.assertEquals("(?P<group{temp_key}>{temp_regex})|(?P<group{x_key}>{x_regex})".format(**locals()), matcher.pattern)
+		self.assertEqual("(?P<group{temp_key}>{temp_regex})|(?P<group{x_key}>{x_regex})".format(**locals()), matcher.pattern)
 
 	@data(
 		("G4 P2.0", "floatP", True, "2.0"),
@@ -178,7 +178,7 @@ class TestCommHelpers(unittest.TestCase):
 
 		if should_match:
 			self.assertIsNotNone(match)
-			self.assertEquals(expected_value, match.group("value"))
+			self.assertEqual(expected_value, match.group("value"))
 		else:
 			self.assertIsNone(match)
 
@@ -196,7 +196,7 @@ class TestCommHelpers(unittest.TestCase):
 	def test_gcode_command_for_cmd(self, cmd, expected):
 		from octoprint.util.comm import gcode_command_for_cmd
 		result = gcode_command_for_cmd(cmd)
-		self.assertEquals(expected, result)
+		self.assertEqual(expected, result)
 
 	@data(
 		("T:23.0 B:60.0", 0, dict(T0=(23.0, None), B=(60.0, None)), 0),
@@ -210,7 +210,7 @@ class TestCommHelpers(unittest.TestCase):
 		from octoprint.util.comm import parse_temperature_line
 		maxtool, result = parse_temperature_line(line, current)
 		self.assertDictEqual(expected_result, result)
-		self.assertEquals(expected_max, maxtool)
+		self.assertEqual(expected_max, maxtool)
 
 	@data(
 		(dict(T=(23.0,None)), 0, dict(T0=(23.0, None))),

--- a/tests/util/test_counted_event.py
+++ b/tests/util/test_counted_event.py
@@ -18,12 +18,12 @@ class CountedEventTest(unittest.TestCase):
 
 		event = CountedEvent()
 
-		self.assertEquals(0, event._counter)
+		self.assertEqual(0, event._counter)
 		self.assertFalse(event._event.is_set())
 
 		event.set()
 
-		self.assertEquals(1, event._counter)
+		self.assertEqual(1, event._counter)
 		self.assertTrue(event._event.is_set())
 
 	def test_set_more_than_max(self):
@@ -31,17 +31,17 @@ class CountedEventTest(unittest.TestCase):
 
 		event = CountedEvent(max=1)
 
-		self.assertEquals(0, event._counter)
+		self.assertEqual(0, event._counter)
 		self.assertFalse(event._event.is_set())
 
 		event.set()
 
-		self.assertEquals(1, event._counter)
+		self.assertEqual(1, event._counter)
 		self.assertTrue(event._event.is_set())
 
 		event.set()
 
-		self.assertEquals(1, event._counter)
+		self.assertEqual(1, event._counter)
 		self.assertTrue(event._event.is_set())
 
 	def test_clear_once(self):
@@ -49,12 +49,12 @@ class CountedEventTest(unittest.TestCase):
 
 		event = CountedEvent(1)
 
-		self.assertEquals(1, event._counter)
+		self.assertEqual(1, event._counter)
 		self.assertTrue(event._event.is_set())
 
 		event.clear()
 
-		self.assertEquals(0, event._counter)
+		self.assertEqual(0, event._counter)
 		self.assertFalse(event._event.is_set())
 
 	def test_clear_all(self):
@@ -62,12 +62,12 @@ class CountedEventTest(unittest.TestCase):
 
 		event = CountedEvent(10)
 
-		self.assertEquals(10, event._counter)
+		self.assertEqual(10, event._counter)
 		self.assertTrue(event._event.is_set())
 
 		event.clear(completely=True)
 
-		self.assertEquals(0, event._counter)
+		self.assertEqual(0, event._counter)
 		self.assertFalse(event._event.is_set())
 
 	def test_clear_more_than_available(self):
@@ -75,17 +75,17 @@ class CountedEventTest(unittest.TestCase):
 
 		event = CountedEvent(1)
 
-		self.assertEquals(1, event._counter)
+		self.assertEqual(1, event._counter)
 		self.assertTrue(event._event.is_set())
 
 		event.clear()
 
-		self.assertEquals(0, event._counter)
+		self.assertEqual(0, event._counter)
 		self.assertFalse(event._event.is_set())
 
 		event.clear()
 
-		self.assertEquals(0, event._counter)
+		self.assertEqual(0, event._counter)
 		self.assertFalse(event._event.is_set())
 
 	def test_blocked(self):

--- a/tests/util/test_file_helpers.py
+++ b/tests/util/test_file_helpers.py
@@ -29,7 +29,7 @@ class BomAwareOpenTest(unittest.TestCase):
 			contents = f.readlines()
 
 		# assert
-		self.assertEquals(len(contents), 3)
+		self.assertEqual(len(contents), 3)
 		self.assertTrue(contents[0].startswith("#"))
 
 	def test_bom_aware_open_without_bom(self):
@@ -40,7 +40,7 @@ class BomAwareOpenTest(unittest.TestCase):
 			contents = f.readlines()
 
 		# assert
-		self.assertEquals(len(contents), 3)
+		self.assertEqual(len(contents), 3)
 		self.assertTrue(contents[0].startswith("#"))
 
 	def test_bom_aware_open_ascii(self):
@@ -51,7 +51,7 @@ class BomAwareOpenTest(unittest.TestCase):
 			contents = f.readlines()
 
 		# assert
-		self.assertEquals(len(contents), 3)
+		self.assertEqual(len(contents), 3)
 		self.assertTrue(contents[0].startswith(u"\ufffd" * 3 + "#"))
 		self.assertTrue(contents[2].endswith(u"\ufffd\ufffd" * 6))
 

--- a/tests/util/test_repeated_timer.py
+++ b/tests/util/test_repeated_timer.py
@@ -51,7 +51,7 @@ class RepeatedTimerTest(unittest.TestCase):
 		# wait for it
 		timer.join()
 
-		self.assertEquals(5, timer_task.call_count)
+		self.assertEqual(5, timer_task.call_count)
 
 	def test_finished_callback(self):
 		countdown = Countdown(5)
@@ -66,7 +66,7 @@ class RepeatedTimerTest(unittest.TestCase):
 		# wait for it
 		timer.join()
 
-		self.assertEquals(1, on_finished.call_count)
+		self.assertEqual(1, on_finished.call_count)
 
 	def test_condition_callback(self):
 		countdown = Countdown(5)
@@ -85,8 +85,8 @@ class RepeatedTimerTest(unittest.TestCase):
 		# wait for it
 		timer.join()
 
-		self.assertEquals(1, on_condition_false.call_count)
-		self.assertEquals(0, on_cancelled.call_count)
+		self.assertEqual(1, on_condition_false.call_count)
+		self.assertEqual(0, on_cancelled.call_count)
 
 	def test_cancelled_callback(self):
 		countdown = Countdown(5)
@@ -109,8 +109,8 @@ class RepeatedTimerTest(unittest.TestCase):
 		timer.cancel()
 		timer.join()
 
-		self.assertEquals(0, on_condition_false.call_count)
-		self.assertEquals(1, on_cancelled.call_count)
+		self.assertEqual(0, on_condition_false.call_count)
+		self.assertEqual(1, on_cancelled.call_count)
 
 	def test_run_first(self):
 		timer_task = mock.MagicMock()
@@ -126,7 +126,7 @@ class RepeatedTimerTest(unittest.TestCase):
 		timer.join()
 
 		# should have run once
-		self.assertEquals(1, timer_task.call_count)
+		self.assertEqual(1, timer_task.call_count)
 
 	def test_not_run_first(self):
 		timer_task = mock.MagicMock()
@@ -141,7 +141,7 @@ class RepeatedTimerTest(unittest.TestCase):
 		timer.cancel()
 		timer.join()
 
-		self.assertEquals(0, timer_task.call_count)
+		self.assertEqual(0, timer_task.call_count)
 
 	def test_adjusted_interval(self):
 		increasing_interval = IncreasingInterval(3, 1)
@@ -159,7 +159,7 @@ class RepeatedTimerTest(unittest.TestCase):
 		timer.join()
 		duration = time.time() - start_time
 
-		self.assertEquals(3, timer_task.call_count)
+		self.assertEqual(3, timer_task.call_count)
 		self.assertGreaterEqual(duration, 6)
 		self.assertLess(duration, 7)
 
@@ -177,4 +177,4 @@ class RepeatedTimerTest(unittest.TestCase):
 		timer.condition = lambda: False
 		timer.join()
 
-		self.assertEquals(1, timer_task.call_count)
+		self.assertEqual(1, timer_task.call_count)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
1) import Queue is now lower caps

2) exceptions
except KeyError as e:

3) assertEquals is deprecated but assertEqual does exactly same thing
#### How was it tested? How can it be tested by the reviewer?
travis ci ran before commit
#### Any background context you want to provide?
python3 compat
#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

