### PR TITLE
python3: xrange got removed from python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ INSTALL_REQUIRES = [
 	"Click>=6.2,<6.3",
 	"awesome-slugify>=1.6.5,<1.7",
 	"feedparser>=5.2.1,<5.3",
-	"chainmap>=1.0.2,<1.1"
+	"chainmap>=1.0.2,<1.1",
+	"future>=0.15,<0.16"
 ]
 
 # Additional requirements for optional install options

--- a/src/octoprint/plugins/cura/profile.py
+++ b/src/octoprint/plugins/cura/profile.py
@@ -7,6 +7,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 
 
 import re
+from builtins import range
 
 class SupportLocationTypes(object):
 	NONE = "none"
@@ -496,7 +497,7 @@ class Profile(object):
 					if not key in result:
 						result[key] = []
 					if len(result[key]) <= index:
-						for n in xrange(index - len(result[key]) + 1):
+						for n in range(index - len(result[key]) + 1):
 							result[key].append(None)
 					result[key][index] = value
 				else:
@@ -549,7 +550,7 @@ class Profile(object):
 			# So override > profile > default, if neither override nor profile value are available
 			# the default value should just be left as is
 
-			for x in xrange(len(result)):
+			for x in range(len(result)):
 				if override_value is not None and  x < len(override_value) and override_value[x] is not None:
 					# we have an override value for this location, so we use it
 					result[x] = override_value[x]
@@ -811,7 +812,7 @@ class Profile(object):
 
 				prefix_preheat = ""
 				prefix_waitheat = ""
-				for n in xrange(0, extruder_count):
+				for n in range(0, extruder_count):
 					if n > 0:
 						prefix_preheat += temp_line(temp, n, "M104 T{extruder} S{temp}\n")
 					prefix_waitheat += temp_line(temp, n, "M109 T{extruder} S{temp}\n")

--- a/src/octoprint/plugins/discovery/__init__.py
+++ b/src/octoprint/plugins/discovery/__init__.py
@@ -12,6 +12,7 @@ The SSDP/UPNP implementations has been largely inspired by https://gist.github.c
 import logging
 import os
 import flask
+from builtins import range
 
 import octoprint.plugin
 import octoprint.util
@@ -409,7 +410,7 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 				"HOST: {mcast_addr}:{mcast_port}\r\n\r\n"
 			])
 
-			for _ in xrange(retries):
+			for _ in range(retries):
 				for addr in octoprint.util.interface_addresses():
 					try:
 						sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
@@ -420,7 +421,7 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 						message = search_message.format(query=query,
 						                                mcast_addr=self.__class__.ssdp_multicast_addr,
 						                                mcast_port=self.__class__.ssdp_multicast_port)
-						for _ in xrange(2):
+						for _ in range(2):
 							sock.sendto(message, (self.__class__.ssdp_multicast_addr, self.__class__.ssdp_multicast_port))
 
 						try:
@@ -541,7 +542,7 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 
 		self._ssdp_monitor_active = False
 		if self.host and self.port:
-			for _ in xrange(2):
+			for _ in range(2):
 				self._ssdp_notify(alive=False)
 
 	def _ssdp_notify(self, alive=True):
@@ -587,7 +588,7 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 				                                nts="ssdp:alive" if alive else "ssdp:byebye",
 				                                mcast_addr=self.__class__.ssdp_multicast_addr,
 				                                mcast_port=self.__class__.ssdp_multicast_port)
-				for _ in xrange(2):
+				for _ in range(2):
 					# send twice, stuff might get lost, it's only UDP
 					sock.sendto(message, (self.__class__.ssdp_multicast_addr, self.__class__.ssdp_multicast_port))
 			except:

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -17,6 +17,7 @@ from babel import Locale
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 from collections import defaultdict
+from builtins import range
 
 import os
 import logging
@@ -330,7 +331,7 @@ class Server(object):
 			import string
 			from random import choice
 			chars = string.ascii_lowercase + string.ascii_uppercase + string.digits
-			secret_key = "".join(choice(chars) for _ in xrange(32))
+			secret_key = "".join(choice(chars) for _ in range(32))
 			self._settings.set(["server", "secretKey"], secret_key)
 			self._settings.save()
 		app.secret_key = secret_key
@@ -917,7 +918,7 @@ class Server(object):
 						# that might be caused by the user still having the folder open somewhere, let's try again after
 						# waiting a bit
 						import time
-						for n in xrange(3):
+						for n in range(3):
 							time.sleep(0.5)
 							self._logger.debug("Creating {path}: Retry #{retry} after {time}s".format(path=path, retry=n+1, time=(n + 1)*0.5))
 							try:

--- a/src/octoprint/users.py
+++ b/src/octoprint/users.py
@@ -14,6 +14,7 @@ import yaml
 import uuid
 
 import logging
+from builtins import range
 
 from octoprint.settings import settings
 
@@ -107,7 +108,7 @@ class UserManager(object):
 				import string
 				from random import choice
 				chars = string.ascii_lowercase + string.ascii_uppercase + string.digits
-				salt = "".join(choice(chars) for _ in xrange(32))
+				salt = "".join(choice(chars) for _ in range(32))
 				settings().set(["accessControl", "salt"], salt)
 				settings().save()
 
@@ -506,7 +507,7 @@ class SessionUser(User):
 		import random
 		import time
 		chars = string.ascii_uppercase + string.ascii_lowercase + string.digits
-		self._session = "".join(random.choice(chars) for _ in xrange(10))
+		self._session = "".join(random.choice(chars) for _ in range(10))
 		self._created = time.time()
 
 	def __getattribute__(self, item):

--- a/src/octoprint/util/avr_isp/intelHex.py
+++ b/src/octoprint/util/avr_isp/intelHex.py
@@ -1,4 +1,5 @@
 import io
+from builtins import range
 
 def readHex(filename):
 	data = []
@@ -14,7 +15,7 @@ def readHex(filename):
 		if len(line) != recLen * 2 + 11:
 			raise Exception("Error in hex file: " + line)
 		checkSum = 0
-		for i in xrange(0, recLen + 5):
+		for i in range(0, recLen + 5):
 			checkSum += int(line[i*2+1:i*2+3], 16)
 		checkSum &= 0xFF
 		if checkSum != 0:
@@ -23,7 +24,7 @@ def readHex(filename):
 		if recType == 0:#Data record
 			while len(data) < addr + recLen:
 				data.append(0)
-			for i in xrange(0, recLen):
+			for i in range(0, recLen):
 				data[addr + i] = int(line[i*2+9:i*2+11], 16)
 		elif recType == 1:	#End Of File record
 			pass

--- a/src/octoprint/util/avr_isp/stk500v2.py
+++ b/src/octoprint/util/avr_isp/stk500v2.py
@@ -2,6 +2,7 @@ import os, struct, sys, time
 
 from serial import Serial
 from serial import SerialException
+from builtins import range
 
 import ispBase, intelHex
 
@@ -67,7 +68,7 @@ class Stk500v2(ispBase.IspBase):
 			self.sendMessage([0x06, 0x00, 0x00, 0x00, 0x00])
 		
 		loadCount = (len(flashData) + pageSize - 1) / pageSize
-		for i in xrange(0, loadCount):
+		for i in range(0, loadCount):
 			recv = self.sendMessage([0x13, pageSize >> 8, pageSize & 0xFF, 0xc1, 0x0a, 0x40, 0x4c, 0x20, 0x00, 0x00] + flashData[(i * pageSize):(i * pageSize + pageSize)])
 			if self.progressCallback != None:
 				self.progressCallback(i + 1, loadCount*2)
@@ -81,11 +82,11 @@ class Stk500v2(ispBase.IspBase):
 			self.sendMessage([0x06, 0x00, 0x00, 0x00, 0x00])
 		
 		loadCount = (len(flashData) + 0xFF) / 0x100
-		for i in xrange(0, loadCount):
+		for i in range(0, loadCount):
 			recv = self.sendMessage([0x14, 0x01, 0x00, 0x20])[2:0x102]
 			if self.progressCallback != None:
 				self.progressCallback(loadCount + i + 1, loadCount*2)
-			for j in xrange(0, 0x100):
+			for j in range(0, 0x100):
 				if i * 0x100 + j < len(flashData) and flashData[i * 0x100 + j] != recv[j]:
 					raise ispBase.IspError('Verify error at: 0x%x' % (i * 0x100 + j))
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
python3 range is = python2 xrange
to make python 2 range = with python3 range i used the future package
and did
from builtins import range
#### How was it tested? How can it be tested by the reviewer?
travs-ci
#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

