### PR TITLE
python3: iterators, bytes and next

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -17,6 +17,7 @@ from babel import Locale
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 from collections import defaultdict
+from builtins import bytes
 
 import os
 import logging
@@ -69,7 +70,7 @@ from octoprint.server.util.flask import PreemptiveCache
 
 from . import util
 
-UI_API_KEY = ''.join('%02X' % ord(z) for z in uuid.uuid4().bytes)
+UI_API_KEY = ''.join('%02X' % z for z in bytes(uuid.uuid4().bytes))
 
 VERSION = __version__
 BRANCH = __branch__

--- a/src/octoprint/server/api/printer.py
+++ b/src/octoprint/server/api/printer.py
@@ -91,7 +91,7 @@ def printerToolCommand():
 
 		# make sure the targets are valid and the values are numbers
 		validated_values = {}
-		for tool, value in targets.iteritems():
+		for tool, value in targets.items():
 			if re.match(validation_regex, tool) is None:
 				return make_response("Invalid target for setting temperature: %s" % tool, 400)
 			if not isinstance(value, (int, long, float)):
@@ -108,7 +108,7 @@ def printerToolCommand():
 
 		# make sure the targets are valid, the values are numbers and in the range [-50, 50]
 		validated_values = {}
-		for tool, value in offsets.iteritems():
+		for tool, value in offsets.items():
 			if re.match(validation_regex, tool) is None:
 				return make_response("Invalid target for setting temperature: %s" % tool, 400)
 			if not isinstance(value, (int, long, float)):

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -137,7 +137,7 @@ class UploadStorageFallbackHandler(tornado.web.RequestHandler):
 		self._path = path
 
 		self._suffixes = dict((key, key) for key in ("name", "path", "content_type", "size"))
-		for suffix_type, suffix in suffixes.iteritems():
+		for suffix_type, suffix in suffixes.items():
 			if suffix_type in self._suffixes and suffix is not None:
 				self._suffixes[suffix_type] = suffix
 
@@ -357,7 +357,7 @@ class UploadStorageFallbackHandler(tornado.web.RequestHandler):
 		"""
 
 		self._new_body = b""
-		for name, part in self._parts.iteritems():
+		for name, part in self._parts.items():
 			if "filename" in part:
 				# add form fields for filename, path, size and content_type for all files contained in the request
 				if not "path" in part:
@@ -371,8 +371,8 @@ class UploadStorageFallbackHandler(tornado.web.RequestHandler):
 				if "content_type" in part:
 					parameters["content_type"] = part["content_type"]
 
-				fields = dict((self._suffixes[key], value) for (key, value) in parameters.iteritems())
-				for n, p in fields.iteritems():
+				fields = dict((self._suffixes[key], value) for (key, value) in parameters.items())
+				for n, p in fields.items():
 					key = name + "." + n
 					self._new_body += b"--%s\r\n" % self._multipart_boundary
 					self._new_body += b"Content-Disposition: form-data; name=\"%s\"\r\n" % key

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -30,6 +30,7 @@ import logging
 import re
 import uuid
 import copy
+from builtins import bytes
 
 try:
 	from collections import ChainMap
@@ -516,7 +517,7 @@ class Settings(object):
 		self.load(migrate=True)
 
 		if self.get(["api", "key"]) is None:
-			self.set(["api", "key"], ''.join('%02X' % ord(z) for z in uuid.uuid4().bytes))
+			self.set(["api", "key"], ''.join('%02X' % z for z in bytes(uuid.uuid4().bytes)))
 			self.save(force=True)
 
 		self._script_env = self._init_script_templating()

--- a/src/octoprint/users.py
+++ b/src/octoprint/users.py
@@ -14,6 +14,7 @@ import yaml
 import uuid
 
 import logging
+from builtins import bytes
 
 from octoprint.settings import settings
 
@@ -346,7 +347,7 @@ class FilebasedUserManager(UserManager):
 			raise UnknownUser(username)
 
 		user = self._users[username]
-		user._apikey = ''.join('%02X' % ord(z) for z in uuid.uuid4().bytes)
+		user._apikey = ''.join('%02X' % z for z in bytes(uuid.uuid4().bytes))
 		self._dirty = True
 		self._save()
 		return user._apikey

--- a/src/octoprint/util/jinja.py
+++ b/src/octoprint/util/jinja.py
@@ -95,7 +95,7 @@ class ExceptionHandlerExtension(Extension):
 		self._logger = logging.getLogger(__name__)
 
 	def parse(self, parser):
-		token = parser.stream.next()
+		token = next(parser.stream)
 		lineno = token.lineno
 		filename = parser.name
 		error = parser.parse_expression()


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
python 3 compatibility

iteritems got removed items is to be used for python 2 and 3
compatibility , it returns a view in python 3 and must be casted to a
list if the list is needed.

bytes form builtins

using builtin function next is the compatible way between python 2 and 3
#### How was it tested? How can it be tested by the reviewer?
travis ci
#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
