### PR TITLE
python3: [DO NOT MERGE] just for feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@
 language: python
 python:
 - "2.7"
+- "3.5"
 install:
 - pip install -e .[develop]
 script:
-- nosetests --with-doctest
+- nosetests --with-doctest --with-coverage
 sudo: false
 git:
   depth: 250

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,13 @@ import octoprint_setuptools
 
 # Requirements for our application
 INSTALL_REQUIRES = [
-	"flask>=0.9,<0.11",
-	"werkzeug>=0.8.3,<0.9",
+	"flask>=0.10,<0.12",
+	"werkzeug>=0.9,<=0.9",
 	"tornado>=4.0.2,<4.1",
 	"sockjs-tornado>=1.0.2,<1.1",
 	"PyYAML>=3.10,<3.11",
 	"Flask-Login>=0.2.2,<0.3",
-	"Flask-Principal>=0.3.5,<0.4",
+	"Flask-Principal>=0.4,<0.5",
 	"Flask-Babel>=0.9,<0.10",
 	"Flask-Assets>=0.10,<0.11",
 	"Flask-Markdown>=0.3,<0.4",
@@ -28,7 +28,7 @@ INSTALL_REQUIRES = [
 	"netaddr>=0.7.17,<0.8",
 	"watchdog>=0.8.3,<0.9",
 	"sarge>=0.1.4,<0.2",
-	"netifaces>=0.10,<0.11",
+	"gns3-netifaces>=0.10,<0.11",
 	"pylru>=1.0.9,<1.1",
 	"rsa>=3.2,<3.3",
 	"pkginfo>=1.2.1,<1.3",
@@ -47,8 +47,10 @@ EXTRA_REQUIRES = dict(
 	# Dependencies for developing OctoPrint
 	develop=[
 		# Testing dependencies
-		"mock>=1.0.1,<1.1",
+		"mock>=2.0.0,<2.1.0",
 		"nose>=1.3.0,<1.4",
+		"doctest-ignore-unicode>=0.1.2,<0.2"
+		"coverage>=4.1,<4.2",
 		"ddt",
 
 		# Documentation dependencies
@@ -158,6 +160,7 @@ def params():
 		"Natural Language :: English",
 		"Operating System :: OS Independent",
 		"Programming Language :: Python :: 2.7",
+		"Programming Language :: Python :: 3.5",
 		"Programming Language :: JavaScript",
 		"Topic :: Internet :: WWW/HTTP",
 		"Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ EXTRA_REQUIRES = dict(
 		# Testing dependencies
 		"mock>=2.0.0,<2.1.0",
 		"nose>=1.3.0,<1.4",
-		"doctest-ignore-unicode>=0.1.2,<0.2"
+		"doctest-ignore-unicode>=0.1.2,<0.2",
 		"coverage>=4.1,<4.2",
 		"ddt",
 

--- a/src/octoprint/__init__.py
+++ b/src/octoprint/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import logging
+import io
 
 #~~ version
 
@@ -171,7 +172,7 @@ def init_logging(settings, use_logging_file=True, logging_file=None, default_con
 		config_from_file = {}
 		if os.path.exists(logging_file) and os.path.isfile(logging_file):
 			import yaml
-			with open(logging_file, "r") as f:
+			with io.open(logging_file, 'rt', encoding='utf-8') as f:
 				config_from_file = yaml.safe_load(f)
 
 		# we merge that with the default config

--- a/src/octoprint/_version.py
+++ b/src/octoprint/_version.py
@@ -16,6 +16,7 @@ import os
 import re
 import subprocess
 import sys
+import io
 
 
 def get_keywords():
@@ -130,7 +131,7 @@ def git_get_keywords(versionfile_abs):
     # _version.py.
     keywords = {}
     try:
-        f = open(versionfile_abs, "r")
+        f = io.open(versionfile_abs, 'rt', encoding='utf-8')
         for line in f.readlines():
             if line.strip().startswith("git_refnames ="):
                 mo = re.search(r'=\s*"(.*)"', line)
@@ -307,7 +308,7 @@ def git_parse_lookup_file(path):
 
     import re
     lookup = []
-    with open(path, "r") as f:
+    with io.open(path, 'rt', encoding='utf-8') as f:
         for line in f:
             if '#' in line:
                 line = line[:line.rindex("#")]

--- a/src/octoprint/cli/__init__.py
+++ b/src/octoprint/cli/__init__.py
@@ -6,6 +6,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 
 import click
+click.disable_unicode_literals_warning = True
 import octoprint
 
 #~~ click context

--- a/src/octoprint/cli/client.py
+++ b/src/octoprint/cli/client.py
@@ -5,7 +5,10 @@ __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 import click
+click.disable_unicode_literals_warning = True
 import json
+import io
+from builtins import str
 
 import octoprint_client
 
@@ -94,16 +97,16 @@ def post_from_file(path, file_path, json_flag, yaml_flag):
 	"""POSTs JSON data to the specified server path."""
 	if json_flag or yaml_flag:
 		if json_flag:
-			with open(file_path, "rb") as fp:
+			with io.open(file_path, "rb") as fp:
 				data = json.load(fp)
 		else:
 			import yaml
-			with open(file_path, "rb") as fp:
+			with io.open(file_path, "rb") as fp:
 				data = yaml.safe_load(fp)
 
 		r = octoprint_client.post_json(path, data)
 	else:
-		with open(file_path, "rb") as fp:
+		with io.open(file_path, "rb") as fp:
 			data = fp.read()
 
 		r = octoprint_client.post(path, data)
@@ -114,10 +117,10 @@ def post_from_file(path, file_path, json_flag, yaml_flag):
 @client.command("command")
 @click.argument("path")
 @click.argument("command")
-@click.option("--str", "-s", "str_params", multiple=True, nargs=2, type=click.Tuple([unicode, unicode]))
-@click.option("--int", "-i", "int_params", multiple=True, nargs=2, type=click.Tuple([unicode, int]))
-@click.option("--float", "-f", "float_params", multiple=True, nargs=2, type=click.Tuple([unicode, float]))
-@click.option("--bool", "-b", "bool_params", multiple=True, nargs=2, type=click.Tuple([unicode, bool]))
+@click.option("--str", "-s", "str_params", multiple=True, nargs=2, type=click.Tuple([str,]))
+@click.option("--int", "-i", "int_params", multiple=True, nargs=2, type=click.Tuple([str, int]))
+@click.option("--float", "-f", "float_params", multiple=True, nargs=2, type=click.Tuple([str, float]))
+@click.option("--bool", "-b", "bool_params", multiple=True, nargs=2, type=click.Tuple([str, bool]))
 def command(path, command, str_params, int_params, float_params, bool_params):
 	"""Sends a JSON command to the specified server path."""
 	data = dict()
@@ -131,7 +134,7 @@ def command(path, command, str_params, int_params, float_params, bool_params):
 @client.command("upload")
 @click.argument("path")
 @click.argument("file_path", type=click.Path(exists=True, dir_okay=False, resolve_path=True))
-@click.option("--parameter", "-P", "params", multiple=True, nargs=2, type=click.Tuple([unicode, unicode]))
+@click.option("--parameter", "-P", "params", multiple=True, nargs=2, type=click.Tuple([str,]))
 @click.option("--file-name", type=click.STRING)
 @click.option("--content-type", type=click.STRING)
 def upload(path, file_path, params, file_name, content_type):

--- a/src/octoprint/cli/dev.py
+++ b/src/octoprint/cli/dev.py
@@ -7,6 +7,8 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 
 import click
+click.disable_unicode_literals_warning = True
+from past.builtins import basestring
 
 class OctoPrintDevelCommands(click.MultiCommand):
 	"""

--- a/src/octoprint/cli/plugins.py
+++ b/src/octoprint/cli/plugins.py
@@ -6,6 +6,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 
 import click
+click.disable_unicode_literals_warning = True
 import logging
 
 from octoprint.cli import pass_octoprint_ctx, OctoPrintContext

--- a/src/octoprint/cli/server.py
+++ b/src/octoprint/cli/server.py
@@ -6,6 +6,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 
 import click
+click.disable_unicode_literals_warning = True
 import logging
 import sys
 

--- a/src/octoprint/daemon.py
+++ b/src/octoprint/daemon.py
@@ -60,9 +60,9 @@ class Daemon:
 		# redirect standard file descriptors
 		sys.stdout.flush()
 		sys.stderr.flush()
-		si = open(os.devnull, 'r')
-		so = open(os.devnull, 'a+')
-		se = open(os.devnull, 'a+')
+		si = io.open(os.devnull, 'r')
+		so = io.open(os.devnull, 'a+')
+		se = io.open(os.devnull, 'a+')
 
 		os.dup2(si.fileno(), sys.stdin.fileno())
 		os.dup2(so.fileno(), sys.stdout.fileno())
@@ -142,7 +142,7 @@ class Daemon:
 	def get_pid(self):
 		"""Get the pid from the pidfile."""
 		try:
-			with open(self.pidfile,'r') as pf:
+			with io.open(self.pidfile,'rt', encoding='utf-8') as pf:
 				pid = int(pf.read().strip())
 		except (IOError, ValueError):
 			pid = None
@@ -150,7 +150,7 @@ class Daemon:
 
 	def set_pid(self, pid):
 		"""Write the pid to the pidfile."""
-		with open(self.pidfile,'w+') as f:
+		with io.open(self.pidfile,'wt+', encoding='utf-8') as f:
 			f.write(str(pid) + '\n')
 
 	def remove_pidfile(self):

--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -7,6 +7,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 
 import logging
 import os
+import io
 
 import octoprint.plugin
 import octoprint.util
@@ -19,6 +20,8 @@ from .storage import LocalFileStorage
 from .util import AbstractFileWrapper, StreamWrapper, DiskFileWrapper
 
 from collections import namedtuple
+from past.builtins import basestring
+from builtins import str
 
 ContentTypeMapping = namedtuple("ContentTypeMapping", "extensions, content_type")
 ContentTypeDetector = namedtuple("ContentTypeDetector", "extensions, detector")
@@ -486,7 +489,7 @@ class FileManager(object):
 
 		import yaml
 		try:
-			with open(self._recovery_file) as f:
+			with io.open(self._recovery_file, 'rt', encoding='utf-8') as f:
 				data = yaml.safe_load(f)
 			return data
 		except:

--- a/src/octoprint/filemanager/storage.py
+++ b/src/octoprint/filemanager/storage.py
@@ -10,10 +10,13 @@ import logging
 import os
 import pylru
 import shutil
+import io
 
 from octoprint.util import atomic_write
 from contextlib import contextmanager
 from copy import deepcopy
+from past.builtins import basestring
+from builtins import str
 
 import octoprint.filemanager
 
@@ -418,7 +421,7 @@ class LocalFileStorage(StorageInterface):
 		if os.path.exists(old_metadata_path):
 			# load the old metadata file
 			try:
-				with open(old_metadata_path) as f:
+				with io.open(old_metadata_path, 'rt', encoding='utf-8') as f:
 					import yaml
 					self._old_metadata = yaml.safe_load(f)
 			except:
@@ -748,7 +751,7 @@ class LocalFileStorage(StorageInterface):
 		include a trailing slash for a string ``path`` or an empty last element for a list ``path``.
 		"""
 		name = None
-		if isinstance(path, (str, unicode, basestring)):
+		if isinstance(path, (str)):
 			if path.startswith(self.basefolder):
 				path = path[len(self.basefolder):]
 			path = path.replace(os.path.sep, "/")
@@ -801,7 +804,7 @@ class LocalFileStorage(StorageInterface):
 	def path_in_storage(self, path):
 		if isinstance(path, (tuple, list)):
 			path = self.join_path(*path)
-		if isinstance(path, (str, unicode, basestring)):
+		if isinstance(path, (str)):
 			if path.startswith(self.basefolder):
 				path = path[len(self.basefolder):]
 			path = path.replace(os.path.sep, "/")
@@ -1152,7 +1155,7 @@ class LocalFileStorage(StorageInterface):
 
 		blocksize = 65536
 		hash = hashlib.sha1()
-		with open(path, "rb") as f:
+		with io.open(path, "rb") as f:
 			buffer = f.read(blocksize)
 			while len(buffer) > 0:
 				hash.update(buffer)
@@ -1207,7 +1210,7 @@ class LocalFileStorage(StorageInterface):
 
 			metadata_path = os.path.join(path, ".metadata.yaml")
 			if os.path.exists(metadata_path):
-				with open(metadata_path) as f:
+				with io.open(metadata_path, 'rt', encoding='utf-8') as f:
 					try:
 						import yaml
 						metadata = yaml.safe_load(f)

--- a/src/octoprint/plugin/core.py
+++ b/src/octoprint/plugin/core.py
@@ -31,6 +31,7 @@ import os
 import imp
 from collections import defaultdict, namedtuple, OrderedDict
 import logging
+import io
 
 import pkg_resources
 import pkginfo
@@ -1288,7 +1289,7 @@ def is_editable_install(install_dir, package, module, location):
 	if os.path.isfile(package_link):
 		expected_target = os.path.normcase(os.path.realpath(location))
 		try:
-			with open(package_link) as f:
+			with io.open(package_link, 'rt', encoding='utf-8') as f:
 				contents = f.readlines()
 			for line in contents:
 				target = os.path.normcase(os.path.realpath(os.path.join(line.strip(), module)))
@@ -1346,7 +1347,7 @@ class InstalledEntryPoint(pkginfo.Installed):
 					else:
 						path = candidate
 					if os.path.exists(path):
-						with open(path) as f:
+						with io.open(path, 'rt', encoding='utf-8') as f:
 							return f.read()
 		warnings.warn('No PKG-INFO found for package: %s' % self.package_name)
 

--- a/src/octoprint/plugin/types.py
+++ b/src/octoprint/plugin/types.py
@@ -20,6 +20,7 @@ __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
+from past.builtins import basestring
 
 from .core import (Plugin, RestartNeedingPlugin, SortablePlugin)
 

--- a/src/octoprint/plugins/announcements/__init__.py
+++ b/src/octoprint/plugins/announcements/__init__.py
@@ -20,7 +20,7 @@ import flask
 
 from octoprint.server import admin_permission
 from octoprint.server.util.flask import restricted_access
-from flask.ext.babel import gettext
+from flask_babel import gettext
 
 class AnnouncementPlugin(octoprint.plugin.AssetPlugin,
                          octoprint.plugin.SettingsPlugin,
@@ -253,7 +253,7 @@ class AnnouncementPlugin(octoprint.plugin.AssetPlugin,
 			now = time.time()
 			if os.stat(channel_path).st_mtime + ttl > now:
 				d = feedparser.parse(channel_path)
-				self._logger.debug(u"Loaded channel {} from cache at {}".format(key, channel_path))
+				self._logger.debug("Loaded channel {} from cache at {}".format(key, channel_path))
 				return d
 
 		return None
@@ -267,15 +267,15 @@ class AnnouncementPlugin(octoprint.plugin.AssetPlugin,
 		try:
 			start = time.time()
 			r = requests.get(url)
-			self._logger.info(u"Loaded channel {} from {} in {:.2}s".format(key, config["url"], time.time() - start))
+			self._logger.info("Loaded channel {} from {} in {:.2}s".format(key, config["url"], time.time() - start))
 		except Exception as e:
 			self._logger.exception(
-				u"Could not fetch channel {} from {}: {}".format(key, config["url"], str(e)))
+				"Could not fetch channel {} from {}: {}".format(key, config["url"], str(e)))
 			return None
 
 		response = r.text
 		channel_path = self._get_channel_cache_path(key)
-		with codecs.open(channel_path, mode="w", encoding="utf-8") as f:
+		with codecs.open(channel_path, mode="wt", encoding="utf-8") as f:
 			f.write(response)
 		return feedparser.parse(response)
 
@@ -321,13 +321,15 @@ def _strip_images(text):
 
 def _strip_tags(text):
 	"""
-	>>> _strip_tags(u"<a href='test.html'>Hello world</a>&lt;img src='foo.jpg'&gt;")
-	u"Hello world&lt;img src='foo.jpg'&gt;"
-	>>> _strip_tags(u"&#62; &#x3E; Foo")
-	u'&#62; &#x3E; Foo'
+	>>> _strip_tags("<a href='test.html'>Hello world</a>&lt;img src='foo.jpg'&gt;")
+	"Hello world&lt;img src='foo.jpg'&gt;"
+	>>> _strip_tags("&#62; &#x3E; Foo")
+	'&#62; &#x3E; Foo'
 	"""
-
-	from HTMLParser import HTMLParser
+	try:
+		from HTMLParser import HTMLParser
+	except ImportError:
+		from html.parser import HTMLParser
 
 	class TagStripper(HTMLParser):
 

--- a/src/octoprint/plugins/corewizard/__init__.py
+++ b/src/octoprint/plugins/corewizard/__init__.py
@@ -9,7 +9,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 import octoprint.plugin
 
 
-from flask.ext.babel import gettext
+from flask_babel import gettext
 
 
 class CoreWizardPlugin(octoprint.plugin.AssetPlugin,

--- a/src/octoprint/plugins/cura/profile.py
+++ b/src/octoprint/plugins/cura/profile.py
@@ -8,6 +8,8 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 
 import re
 from builtins import range
+from past.builtins import basestring
+from builtins import str
 
 class SupportLocationTypes(object):
 	NONE = "none"
@@ -359,9 +361,11 @@ class Profile(object):
 		if not os.path.exists(path) or not os.path.isfile(path):
 			logger.warn("Path {path} does not exist or is not a file, cannot import".format(**locals()))
 			return None
-
-		import ConfigParser
-		config = ConfigParser.ConfigParser()
+		try:
+			import configparser
+		except ImportError:
+			import ConfigParser as configparser
+		config = configparser.ConfigParser()
 		try:
 			config.read(path)
 		except:
@@ -671,7 +675,7 @@ class Profile(object):
 		if value is None:
 			return default
 
-		if isinstance(value, (str, unicode, basestring)):
+		if isinstance(value, (str)):
 			value = value.replace(",", ".").strip()
 
 		try:
@@ -686,7 +690,7 @@ class Profile(object):
 
 		if isinstance(value, bool):
 			return value
-		elif isinstance(value, (str, unicode, basestring)):
+		elif isinstance(value, (str)):
 			return value.lower() == "true" or value.lower() == "yes" or value.lower() == "on" or value == "1"
 		elif isinstance(value, (int, float)):
 			return value > 0
@@ -725,7 +729,7 @@ class Profile(object):
 
 		result = []
 		for k, v in profile.items():
-			if isinstance(v, (str, unicode)):
+			if isinstance(v, (str)):
 				result.append("{k}={v}".format(k=k, v=v.encode("utf-8")))
 			else:
 				result.append("{k}={v}".format(k=k, v=v))
@@ -780,7 +784,7 @@ class Profile(object):
 		else:
 			contents = self.get_gcode_template(key)
 
-		return unicode(prefix + re.sub("(.)\{([^\}]*)\}", self.replaceTagMatch, contents).rstrip() + '\n' + postfix).strip().encode('utf-8') + '\n'
+		return str(prefix + re.sub("(.)\{([^\}]*)\}", self.replaceTagMatch, contents).rstrip() + '\n' + postfix).strip().encode('utf-8') + '\n'
 
 	def get_start_gcode_prefix(self, contents):
 		extruder_count = self.get_int("extruder_amount")

--- a/src/octoprint/plugins/discovery/__init__.py
+++ b/src/octoprint/plugins/discovery/__init__.py
@@ -198,7 +198,7 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 
 		key = (reg_type, port)
 		self._sd_refs[key] = pybonjour.DNSServiceRegister(**params)
-		self._logger.info(u"Registered {name} for {reg_type}".format(**locals()))
+		self._logger.info("Registered {name} for {reg_type}".format(**locals()))
 
 	def zeroconf_unregister(self, reg_type, port=None):
 		"""
@@ -381,10 +381,12 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 		"""
 
 		import threading
-
-		import httplib
+		try:
+			import http.client as httpc
+		except ImportError:
+			import httplib as httpc
 		import io
-		class Response(httplib.HTTPResponse):
+		class Response(httpc.HTTPResponse):
 			def __init__(self, response_text):
 				self.fp = io.BytesIO(response_text)
 				self.debuglevel = 0
@@ -603,9 +605,14 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 		:param timeout: timeout after which to stop waiting for M-SEARCHs for a short while in order to put out an
 		                alive message
 		"""
-
-		from BaseHTTPServer import BaseHTTPRequestHandler
-		from StringIO import StringIO
+		try:
+			from http.server import BaseHTTPRequestHandler
+		except ImportError:
+			from BaseHTTPServer import BaseHTTPRequestHandler
+		try:
+			from io import StringIO
+		except ImportError:
+			from StringIO import StringIO
 		import socket
 
 		socket.setdefaulttimeout(timeout)
@@ -637,7 +644,7 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 
 		sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, socket.inet_aton(self.__class__.ssdp_multicast_addr) + socket.inet_aton('0.0.0.0'))
 
-		self._logger.info(u"Registered {} for SSDP".format(self.get_instance_name()))
+		self._logger.info("Registered {} for SSDP".format(self.get_instance_name()))
 
 		self._ssdp_notify(alive=True)
 
@@ -678,7 +685,7 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 	def get_instance_name(self):
 		name = self._settings.global_get(["appearance", "name"])
 		if name:
-			return u"OctoPrint instance \"{}\"".format(name)
+			return "OctoPrint instance \"{}\"".format(name)
 		else:
 			import socket
-			return u"OctoPrint instance on {}".format(socket.gethostname())
+			return "OctoPrint instance on {}".format(socket.gethostname())

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -15,7 +15,7 @@ from octoprint.server import admin_permission, VERSION
 from octoprint.util.pip import LocalPipCaller, UnknownPip
 
 from flask import jsonify, make_response
-from flask.ext.babel import gettext
+from flask_babel import gettext
 
 import logging
 import sarge
@@ -24,6 +24,7 @@ import requests
 import re
 import os
 import pkg_resources
+import io
 
 class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
                           octoprint.plugin.TemplatePlugin,
@@ -352,7 +353,7 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 			return make_response("Bundled plugins cannot be uninstalled", 403)
 
 		if plugin.origin is None:
-			self._logger.warn(u"Trying to uninstall plugin {plugin} but origin is unknown".format(**locals()))
+			self._logger.warn("Trying to uninstall plugin {plugin} but origin is unknown".format(**locals()))
 			return make_response("Could not uninstall plugin, its origin is unknown")
 
 		if plugin.origin.type == "entry_point":
@@ -365,7 +366,7 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 			try:
 				self._call_pip(pip_args)
 			except:
-				self._logger.exception(u"Could not uninstall plugin via pip")
+				self._logger.exception("Could not uninstall plugin via pip")
 				return make_response("Could not uninstall plugin via pip, see the log for more details", 500)
 
 		elif plugin.origin.type == "folder":
@@ -375,10 +376,10 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 
 			if os.path.isdir(full_path):
 				# plugin is installed via a plugin folder, need to use rmtree to get rid of it
-				self._log_stdout(u"Deleting plugin from {folder}".format(folder=plugin.location))
+				self._log_stdout("Deleting plugin from {folder}".format(folder=plugin.location))
 				shutil.rmtree(full_path)
 			elif os.path.isfile(full_path):
-				self._log_stdout(u"Deleting plugin from {file}".format(file=plugin.location))
+				self._log_stdout("Deleting plugin from {file}".format(file=plugin.location))
 				os.remove(full_path)
 
 				if full_path.endswith(".py"):
@@ -387,7 +388,7 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 						os.remove(pyc_file)
 
 		else:
-			self._logger.warn(u"Trying to uninstall plugin {plugin} but origin is unknown ({plugin.origin.type})".format(**locals()))
+			self._logger.warn("Trying to uninstall plugin {plugin} but origin is unknown ({plugin.origin.type})".format(**locals()))
 			return make_response("Could not uninstall plugin, its origin is unknown")
 
 		needs_restart = self._plugin_manager.is_restart_needing_plugin(plugin)
@@ -402,7 +403,7 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 			try:
 				self._plugin_manager.disable_plugin(plugin.key, plugin=plugin)
 			except octoprint.plugin.core.PluginLifecycleException as e:
-				self._logger.exception(u"Problem disabling plugin {name}".format(name=plugin.key))
+				self._logger.exception("Problem disabling plugin {name}".format(name=plugin.key))
 				result = dict(result=False, uninstalled=True, disabled=False, unloaded=False, reason=e.reason)
 				self._send_result_notification("uninstall", result)
 				return jsonify(result)
@@ -410,7 +411,7 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 			try:
 				self._plugin_manager.unload_plugin(plugin.key)
 			except octoprint.plugin.core.PluginLifecycleException as e:
-				self._logger.exception(u"Problem unloading plugin {name}".format(name=plugin.key))
+				self._logger.exception("Problem unloading plugin {name}".format(name=plugin.key))
 				result = dict(result=False, uninstalled=True, disabled=True, unloaded=False, reason=e.reason)
 				self._send_result_notification("uninstall", result)
 				return jsonify(result)
@@ -438,7 +439,7 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 			elif command == "enable":
 				self._mark_plugin_enabled(plugin, needs_restart=needs_restart)
 		except octoprint.plugin.core.PluginLifecycleException as e:
-			self._logger.exception(u"Problem toggling enabled state of {name}: {reason}".format(name=plugin.key, reason=e.reason))
+			self._logger.exception("Problem toggling enabled state of {name}: {reason}".format(name=plugin.key, reason=e.reason))
 			result = dict(result=False, reason=e.reason)
 		except octoprint.plugin.core.PluginNeedsRestart:
 			result = dict(result=True, needs_restart=True, needs_refresh=True, plugin=self._to_external_representation(plugin))
@@ -455,10 +456,10 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 
 	def _call_pip(self, args):
 		if self._pip_caller is None or not self._pip_caller.available:
-			raise RuntimeError(u"No pip available, can't operate".format(**locals()))
+			raise RuntimeError("No pip available, can't operate".format(**locals()))
 
 		if "--process-dependency-links" in args:
-			self._log_message(u"Installation needs to process external dependencies, that might make it take a bit longer than usual depending on the pip version")
+			self._log_message("Installation needs to process external dependencies, that might make it take a bit longer than usual depending on the pip version")
 
 		additional_args = self._settings.get(["pip_args"])
 		if additional_args:
@@ -467,16 +468,16 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 		return self._pip_caller.execute(*args)
 
 	def _log_message(self, *lines):
-		self._log(lines, prefix=u"*", stream="message")
+		self._log(lines, prefix="*", stream="message")
 
 	def _log_call(self, *lines):
-		self._log(lines, prefix=u" ", stream="call")
+		self._log(lines, prefix=" ", stream="call")
 
 	def _log_stdout(self, *lines):
-		self._log(lines, prefix=u">", stream="stdout")
+		self._log(lines, prefix=">", stream="stdout")
 
 	def _log_stderr(self, *lines):
-		self._log(lines, prefix=u"!", stream="stderr")
+		self._log(lines, prefix="!", stream="stderr")
 
 	def _log(self, lines, prefix=None, stream=None, strip=True):
 		if strip:
@@ -484,7 +485,7 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 
 		self._plugin_manager.send_plugin_message(self._identifier, dict(type="loglines", loglines=[dict(line=line, stream=stream) for line in lines]))
 		for line in lines:
-			self._console_logger.debug(u"{prefix} {line}".format(**locals()))
+			self._console_logger.debug("{prefix} {line}".format(**locals()))
 
 	def _mark_plugin_enabled(self, plugin, needs_restart=False):
 		disabled_list = list(self._settings.global_get(["plugins", "_disabled"]))
@@ -524,7 +525,7 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 			if mtime + self._repository_cache_ttl >= time.time() > mtime:
 				try:
 					import json
-					with open(self._repository_cache_path) as f:
+					with io.open(self._repository_cache_path, 'rt', encoding='utf-8') as f:
 						repo_data = json.load(f)
 					self._logger.info("Loaded plugin repository data from disk, was still valid")
 				except:

--- a/src/octoprint/plugins/softwareupdate/__init__.py
+++ b/src/octoprint/plugins/softwareupdate/__init__.py
@@ -15,6 +15,7 @@ import time
 import logging
 import logging.handlers
 import hashlib
+import io
 
 from . import version_checks, updaters, exceptions, util, cli
 
@@ -110,7 +111,7 @@ class SoftwareUpdatePlugin(octoprint.plugin.BlueprintPlugin,
 
 		import yaml
 		try:
-			with open(self._version_cache_path) as f:
+			with io.open(self._version_cache_path, 'rt', encoding='utf-8') as f:
 				data = yaml.safe_load(f)
 		except:
 			self._logger.exception("Error while loading version cache from disk")
@@ -749,7 +750,7 @@ class SoftwareUpdatePlugin(octoprint.plugin.BlueprintPlugin,
 
 		self._send_client_message("loglines", data=dict(loglines=[dict(line=line, stream=stream) for line in lines]))
 		for line in lines:
-			self._console_logger.debug(u"{prefix} {line}".format(**locals()))
+			self._console_logger.debug("{prefix} {line}".format(**locals()))
 
 	def _send_client_message(self, message_type, data=None):
 		self._plugin_manager.send_plugin_message(self._identifier, dict(type=message_type, data=data))

--- a/src/octoprint/plugins/softwareupdate/cli.py
+++ b/src/octoprint/plugins/softwareupdate/cli.py
@@ -7,6 +7,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 def commands(cli_group, pass_octoprint_ctx, *args, **kwargs):
 	import click
+	click.disable_unicode_literals_warning = True
 	import sys
 	import requests.exceptions
 	import octoprint_client as client

--- a/src/octoprint/plugins/softwareupdate/scripts/update-octoprint.py
+++ b/src/octoprint/plugins/softwareupdate/scripts/update-octoprint.py
@@ -8,6 +8,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 
 import errno
 import sys
+import io
 
 def _log_call(*lines):
 	_log(lines, prefix=">", stream="call")
@@ -27,7 +28,7 @@ def _log(lines, prefix=None, stream=None):
 		output_stream = sys.stderr
 
 	for line in lines:
-		print(u"{} {}".format(prefix, _to_unicode(line.rstrip(), errors="replace")), file=output_stream)
+		print("{} {}".format(prefix, _to_unicode(line.rstrip(), errors="replace")), file=output_stream)
 
 
 def _to_unicode(s_or_u, encoding="utf-8", errors="strict"):
@@ -131,7 +132,7 @@ def _python(args, cwd, python_executable, sudo=False):
 
 
 def _to_error(*lines):
-	return u"".join(map(lambda x: _to_unicode(x, errors="replace"), lines))
+	return "".join(map(lambda x: _to_unicode(x, errors="replace"), lines))
 
 
 def update_source(git_executable, folder, target, force=False):
@@ -151,7 +152,7 @@ def update_source(git_executable, folder, target, force=False):
 		if returncode != 0:
 			raise RuntimeError("Could not update, installation directory was dirty and state could not be persisted as a patch to %s" % patch)
 
-		with open(patch, "wb") as f:
+		with io.open(patch, "wb") as f:
 			for line in stdout:
 				f.write(line)
 

--- a/src/octoprint/plugins/softwareupdate/updaters/pip.py
+++ b/src/octoprint/plugins/softwareupdate/updaters/pip.py
@@ -65,7 +65,7 @@ def perform_update(target, check, target_version, log_cb=None):
 
 	install_arg = check["pip"].format(target_version=target_version)
 
-	logger.debug(u"Target: %s, executing pip install %s" % (target, install_arg))
+	logger.debug("Target: %s, executing pip install %s" % (target, install_arg))
 	pip_args = ["install", check["pip"].format(target_version=target_version, target=target_version)]
 
 	if "dependency_links" in check and check["dependency_links"]:
@@ -75,7 +75,7 @@ def perform_update(target, check, target_version, log_cb=None):
 	if returncode != 0:
 		raise exceptions.UpdateError("Error while executing pip install", (stdout, stderr))
 
-	logger.debug(u"Target: %s, executing pip install %s --ignore-reinstalled --force-reinstall --no-deps" % (target, install_arg))
+	logger.debug("Target: %s, executing pip install %s --ignore-reinstalled --force-reinstall --no-deps" % (target, install_arg))
 	pip_args += ["--ignore-installed", "--force-reinstall", "--no-deps"]
 
 	returncode, stdout, stderr = pip_caller.execute(*pip_args)

--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -9,6 +9,7 @@ import os
 import re
 import threading
 import math
+import io
 try:
 	import queue
 except ImportError:
@@ -767,7 +768,7 @@ class VirtualPrinter(object):
 
 		handle = None
 		try:
-			handle = open(file, "w")
+			handle = io.open(file, "wt", encoding="utf-8")
 		except:
 			self.outgoing.put("error writing to file")
 			if handle is not None:
@@ -794,7 +795,7 @@ class VirtualPrinter(object):
 	def _sdPrintingWorker(self):
 		self._selectedSdFilePos = 0
 		try:
-			with open(self._selectedSdFile, "r") as f:
+			with io.open(self._selectedSdFile, 'rt', encoding='utf-8') as f:
 				for line in iter(f.readline, ""):
 					if self._killed:
 						break

--- a/src/octoprint/printer/profile.py
+++ b/src/octoprint/printer/profile.py
@@ -10,6 +10,7 @@ import os
 import copy
 import re
 import logging
+import io
 
 from octoprint.settings import settings
 from octoprint.util import dict_merge, dict_sanitize, dict_contains_keys, is_hidden_path
@@ -305,7 +306,7 @@ class PrinterProfileManager(object):
 			return None
 
 		import yaml
-		with open(path) as f:
+		with io.open(path, 'rt', encoding='utf-8') as f:
 			profile = yaml.safe_load(f)
 
 		if self._migrate_profile(profile):

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -24,7 +24,8 @@ from octoprint.printer.estimation import TimeEstimationHelper
 from octoprint.settings import settings
 from octoprint.util import comm as comm
 from octoprint.util import InvariantContainer
-from octoprint.util import to_unicode
+from past.builtins import basestring
+from builtins import str
 
 
 class Printer(PrinterInterface, comm.MachineComPrintCallback):
@@ -573,8 +574,8 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
 		remoteName = util.get_dos_filename(filename,
 		                                   existing_filenames=existingSdFiles,
-		                                   extension="gco",
-		                                   whitelisted_extensions=["gco", "g"])
+		                                   extension="GCO",
+		                                   whitelisted_extensions=["GCO", "G"])
 		self._timeEstimationData = TimeEstimationHelper()
 		self._comm.startFileTransfer(absolutePath, filename, "/" + remoteName)
 

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -8,16 +8,19 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 import uuid
 from sockjs.tornado import SockJSRouter
 from flask import Flask, g, request, session, Blueprint
-from flask.ext.login import LoginManager, current_user
-from flask.ext.principal import Principal, Permission, RoleNeed, identity_loaded, UserNeed
-from flask.ext.babel import Babel, gettext, ngettext
-from flask.ext.assets import Environment, Bundle
+from flask_login import LoginManager, current_user
+from flask_principal import Principal, Permission, RoleNeed, identity_loaded, UserNeed
+from flask_babel import Babel, gettext, ngettext
+from flask_assets import Environment, Bundle
 from flaskext.markdown import Markdown
 from babel import Locale
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 from collections import defaultdict
-from builtins import bytes, range
+from builtins import range
+from past.builtins import basestring
+from builtins import bytes
+from builtins import str
 
 import os
 import logging
@@ -25,6 +28,7 @@ import logging.config
 import atexit
 import signal
 import base64
+import io
 
 SUCCESS = {}
 NO_CONTENT = ("", 204)
@@ -665,14 +669,14 @@ class Server(object):
 		def externalize_links(text):
 			def repl(match):
 				tag = match.group("tag")
-				if not u"href" in tag:
+				if not "href" in tag:
 					return match.group(0)
 
-				if not u"target=" in tag and not u"rel=" in tag:
-					tag += u" target=\"_blank\" rel=\"noreferrer noopener\""
+				if not "target=" in tag and not "rel=" in tag:
+					tag += " target=\"_blank\" rel=\"noreferrer noopener\""
 
 				content = match.group("content")
-				return u"<{tag}>{content}</a>".format(tag=tag, content=content)
+				return "<{tag}>{content}</a>".format(tag=tag, content=content)
 			return html_link_regex.sub(repl, text)
 
 		app.jinja_env.filters["regex_replace"] = regex_replace
@@ -1128,7 +1132,7 @@ class Server(object):
 			if not os.path.isfile(path):
 				return ""
 
-			with open(path, "rb") as f:
+			with io.open(path, "rb") as f:
 				data = f.read()
 			return data
 
@@ -1193,7 +1197,7 @@ class LifecycleManager(object):
 			lifecycle_callback(name, plugin)
 
 	def add_callback(self, events, callback):
-		if isinstance(events, (str, unicode)):
+		if isinstance(events, (str)):
 			events = [events]
 
 		for event in events:
@@ -1205,7 +1209,7 @@ class LifecycleManager(object):
 				if callback in self._plugin_lifecycle_callbacks[event]:
 					self._plugin_lifecycle_callbacks[event].remove(callback)
 		else:
-			if isinstance(events, (str, unicode)):
+			if isinstance(events, (str)):
 				events = [events]
 
 			for event in events:

--- a/src/octoprint/server/api/__init__.py
+++ b/src/octoprint/server/api/__init__.py
@@ -10,8 +10,8 @@ import netaddr
 import sarge
 
 from flask import Blueprint, request, jsonify, abort, current_app, session, make_response, g
-from flask.ext.login import login_user, logout_user, current_user
-from flask.ext.principal import Identity, identity_changed, AnonymousIdentity
+from flask_login import login_user, logout_user, current_user
+from flask_principal import Identity, identity_changed, AnonymousIdentity
 
 import octoprint.util as util
 import octoprint.users
@@ -21,6 +21,7 @@ from octoprint.server import admin_permission, NO_CONTENT
 from octoprint.settings import settings as s, valid_boolean_trues
 from octoprint.server.util import noCachingResponseHandler, apiKeyRequestHandler, corsResponseHandler
 from octoprint.server.util.flask import restricted_access, get_json_command_from_request, passive_login
+from functools import reduce
 
 
 #~~ init api blueprint, including sub modules

--- a/src/octoprint/server/api/languages.py
+++ b/src/octoprint/server/api/languages.py
@@ -8,6 +8,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 import os
 import tarfile
 import zipfile
+import io
 
 from collections import defaultdict
 
@@ -21,7 +22,7 @@ from octoprint.server.util.flask import restricted_access
 
 from octoprint.plugin import plugin_manager
 
-from flask.ext.babel import Locale
+from flask_babel import Locale
 
 @api.route("/languages", methods=["GET"])
 @restricted_access
@@ -46,7 +47,7 @@ def getInstalledLanguagePacks():
 			if os.path.isfile(meta_path):
 				import yaml
 				try:
-					with open(meta_path) as f:
+					with io.open(meta_path, 'rt', encoding='utf-8') as f:
 						meta = yaml.safe_load(f)
 				except:
 					pass

--- a/src/octoprint/server/api/printer.py
+++ b/src/octoprint/server/api/printer.py
@@ -7,6 +7,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 
 from flask import request, jsonify, make_response, Response
 from werkzeug.exceptions import BadRequest
+from builtins import str
 import re
 
 from octoprint.settings import settings, valid_boolean_trues
@@ -388,7 +389,7 @@ def _get_temperature_data(preprocessor):
 		tempHistory = printer.get_temperature_history()
 
 		limit = 300
-		if "limit" in request.values.keys() and unicode(request.values["limit"]).isnumeric():
+		if "limit" in request.values.keys() and str(request.values["limit"]).isnumeric():
 			limit = int(request.values["limit"])
 
 		history = list(tempHistory)

--- a/src/octoprint/server/api/printer_profiles.py
+++ b/src/octoprint/server/api/printer_profiles.py
@@ -10,6 +10,7 @@ import copy
 
 from flask import jsonify, make_response, request, url_for
 from werkzeug.exceptions import BadRequest
+from past.builtins import basestring
 
 from octoprint.server.api import api, NO_CONTENT
 from octoprint.server.util.flask import restricted_access

--- a/src/octoprint/server/api/system.py
+++ b/src/octoprint/server/api/system.py
@@ -9,7 +9,7 @@ import logging
 import sarge
 
 from flask import request, make_response, jsonify, url_for
-from flask.ext.babel import gettext
+from flask_babel import gettext
 
 from octoprint.settings import settings as s
 

--- a/src/octoprint/server/api/users.py
+++ b/src/octoprint/server/api/users.py
@@ -7,7 +7,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 
 from flask import request, jsonify, abort, make_response
 from werkzeug.exceptions import BadRequest
-from flask.ext.login import current_user
+from flask_login import current_user
 
 import octoprint.users as users
 

--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -8,9 +8,9 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 
 import tornado.web
 import flask
-import flask.ext.login
-import flask.ext.principal
-import flask.ext.assets
+import flask_login
+import flask_principal
+import flask_assets
 import webassets.updater
 import webassets.utils
 import functools
@@ -21,6 +21,7 @@ import threading
 import logging
 import netaddr
 import os
+import io
 
 from octoprint.settings import settings
 import octoprint.server
@@ -28,7 +29,8 @@ import octoprint.users
 import octoprint.plugin
 
 from werkzeug.contrib.cache import BaseCache
-
+from past.builtins import basestring
+from builtins import bytes
 
 #~~ monkey patching
 
@@ -36,7 +38,7 @@ def enable_additional_translations(default_locale="en", additional_folders=None)
 	import os
 	from flask import _request_ctx_stack
 	from babel import support, Locale
-	import flask.ext.babel
+	import flask_babel
 
 	if additional_folders is None:
 		additional_folders = []
@@ -81,7 +83,7 @@ def enable_additional_translations(default_locale="en", additional_folders=None)
 			return None
 		translations = getattr(ctx, 'babel_translations', None)
 		if translations is None:
-			locale = flask.ext.babel.get_locale()
+			locale = flask_babel.get_locale()
 			translations = support.Translations()
 
 			if str(locale) != default_locale:
@@ -119,8 +121,8 @@ def enable_additional_translations(default_locale="en", additional_folders=None)
 			ctx.babel_translations = translations
 		return translations
 
-	flask.ext.babel.Babel.list_translations = fixed_list_translations
-	flask.ext.babel.get_translations = fixed_get_translations
+	flask_babel.Babel.list_translations = fixed_list_translations
+	flask_babel.get_translations = fixed_get_translations
 
 def fix_webassets_cache():
 	from webassets import cache
@@ -170,7 +172,7 @@ def fix_webassets_cache():
 
 		filename = os.path.join(self.directory, '%s' % hash)
 		try:
-			f = open(filename, 'rb')
+			f = io.open(filename, 'rb')
 		except IOError as e:
 			if e.errno != errno.ENOENT:
 				raise
@@ -215,7 +217,7 @@ def fix_webassets_filtertool():
 			return MemoryHunk(content)
 		except:
 			error_logger.exception("Got an exception while trying to apply filter, ignoring file")
-			return MemoryHunk(u"")
+			return MemoryHunk("")
 
 	FilterTool._wrap_cache = fixed_wrap_cache
 
@@ -223,12 +225,12 @@ def fix_webassets_filtertool():
 
 def passive_login():
 	if octoprint.server.userManager.enabled:
-		user = octoprint.server.userManager.login_user(flask.ext.login.current_user)
+		user = octoprint.server.userManager.login_user(flask_login.current_user)
 	else:
-		user = flask.ext.login.current_user
+		user = flask_login.current_user
 
 	if user is not None and not user.is_anonymous():
-		flask.ext.principal.identity_changed.send(flask.current_app._get_current_object(), identity=flask.ext.principal.Identity(user.get_id()))
+		flask_principal.identity_changed.send(flask.current_app._get_current_object(), identity=flask_principal.Identity(user.get_id()))
 		if hasattr(user, "get_session"):
 			flask.session["usersession.id"] = user.get_session()
 		flask.g.user = user
@@ -248,8 +250,8 @@ def passive_login():
 				user = octoprint.server.userManager.findUser(autologinAs)
 				if user is not None:
 					flask.g.user = user
-					flask.ext.login.login_user(user)
-					flask.ext.principal.identity_changed.send(flask.current_app._get_current_object(), identity=flask.ext.principal.Identity(user.get_id()))
+					flask_login.login_user(user)
+					flask_principal.identity_changed.send(flask.current_app._get_current_object(), identity=flask_principal.Identity(user.get_id()))
 					return flask.jsonify(user.asDict())
 		except:
 			logger = logging.getLogger(__name__)
@@ -441,7 +443,7 @@ class PreemptiveCache(object):
 		cache_data = None
 		with self._lock:
 			try:
-				with open(self.cachefile, "r") as f:
+				with io.open(self.cachefile, 'rt', encoding='utf-8') as f:
 					cache_data = yaml.safe_load(f)
 			except IOError as e:
 				import errno
@@ -658,14 +660,14 @@ def _get_flask_user_from_request(request):
 	:return: the user or None if no user could be determined
 	"""
 	import octoprint.server.util
-	import flask.ext.login
+	import flask_login
 	from octoprint.settings import settings
 
 	apikey = octoprint.server.util.get_api_key(request)
 	if settings().getBoolean(["api", "enabled"]) and apikey is not None:
 		user = octoprint.server.util.get_user_for_apikey(apikey)
 	else:
-		user = flask.ext.login.current_user
+		user = flask_login.current_user
 
 	return user
 
@@ -720,7 +722,7 @@ def restricted_access(func):
 		apikey = octoprint.server.util.get_api_key(flask.request)
 		if apikey == octoprint.server.UI_API_KEY:
 			# UI API key => call regular login_required decorator, we are using browser sessions here
-			return flask.ext.login.login_required(func)(*args, **kwargs)
+			return flask_login.login_required(func)(*args, **kwargs)
 
 		# try to determine user for key
 		user = octoprint.server.util.get_user_for_apikey(apikey)
@@ -728,11 +730,11 @@ def restricted_access(func):
 			# no user or no key => go away
 			return flask.make_response("Invalid API key", 401)
 
-		if not flask.ext.login.login_user(user, remember=False):
+		if not flask_login.login_user(user, remember=False):
 			# user for API key could not be logged in => go away
 			return flask.make_response("Invalid API key", 401)
 
-		flask.ext.principal.identity_changed.send(flask.current_app._get_current_object(), identity=flask.ext.principal.Identity(user.get_id()))
+		flask_principal.identity_changed.send(flask.current_app._get_current_object(), identity=flask_principal.Identity(user.get_id()))
 		return func(*args, **kwargs)
 
 	return decorated_view
@@ -753,7 +755,7 @@ class AppSessionManager(object):
 	def create(self):
 		self._clean_sessions()
 
-		key = ''.join('%02X' % ord(z) for z in uuid.uuid4().bytes)
+		key = ''.join('%02X' % z for z in bytes(uuid.uuid4().bytes))
 		created = time.time()
 		valid_until = created + self.__class__.VALIDITY_UNVERIFIED
 
@@ -831,7 +833,7 @@ def get_json_command_from_request(request, valid_commands):
 
 ##~~ Flask-Assets resolver with plugin asset support
 
-class PluginAssetResolver(flask.ext.assets.FlaskResolver):
+class PluginAssetResolver(flask_assets.FlaskResolver):
 
 	def split_prefix(self, ctx, item):
 		app = ctx.environment._app
@@ -840,14 +842,14 @@ class PluginAssetResolver(flask.ext.assets.FlaskResolver):
 				prefix, plugin, name = item.split("/", 2)
 				blueprint = prefix + "." + plugin
 
-				directory = flask.ext.assets.get_static_folder(app.blueprints[blueprint])
+				directory = flask_assets.get_static_folder(app.blueprints[blueprint])
 				item = name
 				endpoint = blueprint + ".static"
 				return directory, item, endpoint
 			except (ValueError, KeyError):
 				pass
 
-		return flask.ext.assets.FlaskResolver.split_prefix(self, ctx, item)
+		return flask_assets.FlaskResolver.split_prefix(self, ctx, item)
 
 	def resolve_output_to_path(self, ctx, target, bundle):
 		import os

--- a/src/octoprint/server/views.py
+++ b/src/octoprint/server/views.py
@@ -10,6 +10,7 @@ import datetime
 
 from collections import defaultdict
 from flask import request, g, url_for, make_response, render_template, send_from_directory, redirect
+from past.builtins import basestring
 
 import octoprint.plugin
 

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -31,13 +31,16 @@ import logging
 import re
 import uuid
 import copy
+import io
 from builtins import bytes
+from builtins import str
 
 try:
 	from collections import ChainMap
 except ImportError:
 	from chainmap import ChainMap
 
+from past.builtins import basestring
 from octoprint.util import atomic_write, is_hidden_path, dict_merge
 
 _APPNAME = "OctoPrint"
@@ -757,7 +760,7 @@ class Settings(object):
 
 	def load(self, migrate=False):
 		if os.path.exists(self._configfile) and os.path.isfile(self._configfile):
-			with open(self._configfile, "r") as f:
+			with io.open(self._configfile, 'rt', encoding='utf-8') as f:
 				try:
 					self._config = yaml.safe_load(f)
 					self._mtime = self.last_modified
@@ -796,7 +799,7 @@ class Settings(object):
 
 		if isinstance(overlay, basestring):
 			if os.path.exists(overlay) and os.path.isfile(overlay):
-				with open(overlay, "r") as f:
+				with io.open(overlay, 'rt', encoding='utf-8') as f:
 					config = yaml.safe_load(f)
 		elif isinstance(overlay, dict):
 			config = overlay
@@ -1193,7 +1196,7 @@ class Settings(object):
 			return value
 		if isinstance(value, (int, float)):
 			return value != 0
-		if isinstance(value, (str, unicode)):
+		if isinstance(value, (str)):
 			return value.lower() in valid_boolean_trues
 		return value is not None
 

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -11,6 +11,7 @@ import fnmatch
 import datetime
 import sys
 import shutil
+import io
 try:
 	import queue
 except ImportError:
@@ -509,7 +510,7 @@ class Timelapse(object):
 		try:
 			self._logger.debug("Going to capture {} from {}".format(filename, self._snapshot_url))
 			r = requests.get(self._snapshot_url, stream=True)
-			with open (filename, "wb") as f:
+			with io.open(filename, "wb") as f:
 				for chunk in r.iter_content(chunk_size=1024):
 					if chunk:
 						f.write(chunk)

--- a/src/octoprint/users.py
+++ b/src/octoprint/users.py
@@ -5,8 +5,8 @@ __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
-from flask.ext.login import UserMixin
-from flask.ext.principal import Identity
+from flask_login import UserMixin
+from flask_principal import Identity
 from werkzeug.local import LocalProxy
 import hashlib
 import os
@@ -14,6 +14,7 @@ import yaml
 import uuid
 
 import logging
+import io
 from builtins import range, bytes
 
 from octoprint.settings import settings
@@ -206,7 +207,7 @@ class FilebasedUserManager(UserManager):
 	def _load(self):
 		if os.path.exists(self._userfile) and os.path.isfile(self._userfile):
 			self._customized = True
-			with open(self._userfile, "r") as f:
+			with io.open(self._userfile, 'rt', encoding='utf-8') as f:
 				data = yaml.safe_load(f)
 				for name in data.keys():
 					attributes = data[name]

--- a/src/octoprint/util/avr_isp/intelHex.py
+++ b/src/octoprint/util/avr_isp/intelHex.py
@@ -5,7 +5,7 @@ from builtins import range
 def readHex(filename):
 	data = []
 	extraAddr = 0
-	f = io.open(filename, "r")
+	f = io.open(filename, 'rt', encoding='utf-8')
 	for line in f:
 		line = line.strip()
 		if line[0] != ':':

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -19,6 +19,8 @@ import serial
 import octoprint.plugin
 
 from collections import deque
+from past.builtins import basestring
+from builtins import str
 
 from octoprint.util.avr_isp import stk500v2
 from octoprint.util.avr_isp import ispBase
@@ -31,9 +33,12 @@ from octoprint.util import get_exception_string, sanitize_ascii, filter_non_asci
 	to_unicode, bom_aware_open, TypedQueue, TypeAlreadyInQueue
 
 try:
-	import _winreg
-except:
-	pass
+	import winreg
+except ImportError:
+	try:
+		import _winreg as winreg
+	except:
+		pass
 
 _logger = logging.getLogger(__name__)
 
@@ -112,10 +117,10 @@ def serialList():
 	baselist=[]
 	if os.name=="nt":
 		try:
-			key=_winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,"HARDWARE\\DEVICEMAP\\SERIALCOMM")
+			key=winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,"HARDWARE\\DEVICEMAP\\SERIALCOMM")
 			i=0
 			while(1):
-				baselist+=[_winreg.EnumValue(key,i)[1]]
+				baselist+=[winreg.EnumValue(key,i)[1]]
 				i+=1
 		except:
 			pass

--- a/src/octoprint/util/commandline.py
+++ b/src/octoprint/util/commandline.py
@@ -72,7 +72,7 @@ class CommandlineCaller(object):
 			joined_command = " ".join(command)
 		else:
 			joined_command = command
-		self._logger.debug(u"Calling: {}".format(joined_command))
+		self._logger.debug("Calling: {}".format(joined_command))
 		self.on_log_call(joined_command)
 
 		kwargs.update(dict(async=True, stdout=sarge.Capture(), stderr=sarge.Capture()))

--- a/src/octoprint/util/pip.py
+++ b/src/octoprint/util/pip.py
@@ -10,6 +10,7 @@ import sarge
 import sys
 import logging
 import site
+import io
 
 import pkg_resources
 
@@ -340,7 +341,7 @@ class PipCaller(CommandlineCaller):
 				return False, False, False, None
 
 			data = dict()
-			with open(testballoon_output_file) as f:
+			with io.open(testballoon_output_file, 'rt', encoding='utf-8') as f:
 				for line in f:
 					key, value = line.split("=", 2)
 					data[key] = value
@@ -389,7 +390,7 @@ class PipCaller(CommandlineCaller):
 
 		    >>> text = b'some text with some\x1b[?25h ANSI codes for \x1b[31mred words\x1b[39m and\x1b[?25l also some cursor control codes'
 		    >>> PipCaller._preprocess(text)
-		    u'some text with some ANSI codes for red words and also some cursor control codes'
+		    'some text with some ANSI codes for red words and also some cursor control codes'
 		"""
 		return to_unicode(clean_ansi(text))
 

--- a/src/octoprint/util/piptestballoon/setup.py
+++ b/src/octoprint/util/piptestballoon/setup.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 import os
 import sys
+import io
 
 """
 This "python package" doesn't actually install. This is intenional. It is merely
@@ -38,7 +39,7 @@ path = os.environ.get("TESTBALLOON_OUTPUT", None)
 if path is not None:
 	# environment variable set, write to a log
 	path = os.path.abspath(path)
-	with open(path, mode="w+b") as output:
+	with io.open(path, mode="w+b") as output:
 		produce_output(output)
 else:
 	# write to stdout

--- a/src/octoprint_client/__init__.py
+++ b/src/octoprint_client/__init__.py
@@ -7,6 +7,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 import requests
 import time
+import io
 
 apikey = None
 baseurl = None
@@ -288,7 +289,7 @@ def upload(path, file_path, additional=None, file_name=None, content_type=None, 
 	if file_name is None:
 		file_name = os.path.basename(file_path)
 
-	with open(file_path, "rb") as fp:
+	with io.open(file_path, "rb") as fp:
 		if content_type:
 			files = dict(file=(file_name, fp, content_type))
 		else:


### PR DESCRIPTION
this is all work in progress but i would like everyone feedback on few aspects with will determine how i approach the actual change for further pull requests. on python3 compatibility.

1) unicode, i will like to add 
from **future** import ....... unicode_literals 
in all the source code files, and mark with b'ABCxyz' wherever needed and remove u'' for eveywhere else to have everything compatible and conforming to the python3 while having same behavior also on python2. 
or
u'' is recognized by python3  (redundant since all string in py3 are unicode anyway) so we could add u'' on all strings that are not b'' to make things very clear
so is b'xyz' & 'abc' versus b'xyz' & u'abc'  with unicode_literals  imported in both cases. 
choices have same behavior on both python2 and 3 so it's just a matter of preference.

 2) for file opening instead of using open i will like to use io.open that is equivalent with python3 open
and specify the file type as text or binary and the encoding to make things run same on both py2 and 3 and make things very clear

3) update packages versions to include packages that are python 2 and 3 compatible
all changes look more or less ok but i would like some feedback on below change and the reson is that netifaces is a bit abandoned and somebody else made fixes for python3 and renamed the package
    - "netifaces>=0.10,<0.11",
    + "gns3-netifaces>=0.10,<0.11",

4) migrate doctest that looks for u'' strings to unitest so they can pass in both versions or use the doctest-ignore-unicode package to make doctest ignore the u'' and have the tests passing in both python2 and 3

5) not exactly related to python3 migration but noticed it while doing unicode/bytes work is the dos8.3 file names function witch is not generating 8.3 names (as dos/windows) and planing to rewrite the function to behave exactly like what you will find under dos or windows in term of SFN DOS8.3 file names
