### PR TITLE
Fix for bed depth in the printer profile not saving or loading correctly

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/printerprofiles.js
+++ b/src/octoprint/static/js/app/viewmodels/printerprofiles.js
@@ -176,8 +176,8 @@ $(function() {
             self.model(data.model);
 
             self.volumeWidth(data.volume.width);
-            self.volumeHeight(data.volume.depth);
-            self.volumeDepth(data.volume.height);
+            self.volumeHeight(data.volume.height);
+            self.volumeDepth(data.volume.depth);
             self.volumeFormFactor(data.volume.formFactor);
             self.volumeOrigin(data.volume.origin);
 
@@ -220,7 +220,7 @@ $(function() {
                 model: self.model(),
                 volume: {
                     width: parseFloat(self.volumeWidth()),
-                    depth: parseFloat(self.volumeHeight()),
+                    depth: parseFloat(self.volumeDepth()),
                     height: parseFloat(self.volumeHeight()),
                     formFactor: self.volumeFormFactor(),
                     origin: self.volumeOrigin()


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Simple bug fix in the printer profile. The setting Volume -> Y would not save after setting a new value, and in stead would reflect the Volume -> Z setting. 

#### How was it tested? How can it be tested by the reviewer?

Easy to test. In the current devel branch, set the print volume to X:215 Y:200 Z:210 (for example) and then save. Re-open the printer profile and it will read X:215 Y:210 Z:210. Testing with this PR should behave correctly.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

Just a 3 line fix. Should be pretty obvious from the file diff what was wrong.