### PR TITLE
G-code color hack

### DIFF
--- a/src/octoprint/static/gcodeviewer/js/renderer.js
+++ b/src/octoprint/static/gcodeviewer/js/renderer.js
@@ -26,7 +26,7 @@ GCODE.renderer = (function(){
         colorGrid: "#bbbbbb",
         bgColorGrid: "#ffffff",
         bgColorOffGrid: "#eeeeee",
-        colorLine: ["#000000", "#3333cc", "#cc3333", "#33cc33", "#cc33cc"],
+        colorLine: [["#000", "#001", "#002", "#003", "#004", "#005", "#006", "#007", "#008", "#009", "#00a", "#00b", "#00c", "#00d", "#00e", "#00f", "#00f", "#30d", "#60a", "#908", "#b05", "#d03", "#f01", "#f00"], ["#3333cc"], ["#cc3333"], ["#33cc33"], ["#cc33cc"]],
         colorMove: "#00ff00",
         colorRetract: "#ff0000",
         colorRestart: "#0000ff",
@@ -425,6 +425,7 @@ GCODE.renderer = (function(){
         //~~ render this layer's commands
 
         for (i = fromProgress; i <= toProgress; i++) {
+
             ctx.lineWidth = 1;
 
             if (typeof(cmds[i]) === 'undefined') continue;
@@ -452,6 +453,10 @@ GCODE.renderer = (function(){
             // current tool
             var tool = cmds[i].tool;
             if (tool === undefined) tool = 0;
+
+            // color array length inspection
+            var colorArrayLength = renderOptions["colorLine"][tool].length;
+
 
             // line color based on tool
             var lineColor = renderOptions["colorLine"][tool];
@@ -486,7 +491,9 @@ GCODE.renderer = (function(){
             } else if(cmds[i].extrude) {
                 if (cmds[i].retract == 0) {
                     // no retraction => real extrusion move, use tool color to draw line
-                    ctx.strokeStyle = pusher.color(renderOptions["colorLine"][tool]).shade(shade).alpha(alpha).html();
+                    // changing color to visualize progress
+                    ctx.strokeStyle = pusher.color(renderOptions["colorLine"][tool][(toProgress - i < colorArrayLength - 1)?colorArrayLength - 1 - toProgress + i:0]).shade(shade).alpha(alpha).html();
+                    //    ctx.strokeStyle = pusher.color(renderOptions["colorLine"][tool]).shade(shade).alpha(alpha).html();
                     ctx.lineWidth = renderOptions['extrusionWidth'];
                     ctx.beginPath();
                     ctx.moveTo(prevX, prevY);


### PR DESCRIPTION
This time I've read the guidelines ;)
I made this small hack to enable visualization of current print progress and print head location.
The color goes from red through blue to black.
It can be adjusted by modifying the variable renderOptions.
I made all the current colors into an object of 1 child to enable the functionality for multiple tool heads.
I tested it with 2 heads and virtual printer, works OK.
I don't know how to include unit tests for JS to be honest, but I did the manual testing, including one real test print to verify performance impact.

I don't think adding myself for 5 lines of code to the list of Authors is relevant.
----

#### What does this PR do and why is it necessary?
It's nice-to-have feature. As the print progresses, the G-code visualizer renders the last few lines in different color to enable better understanding of current progress/print head.

#### How was it tested? How can it be tested by the reviewer?
I tested manually, using real printer and using virtual printer. Tested 4 different G-codes (from small to 30MB).

#### Any background context you want to provide?
I plan to implement another feature - as a plugin - to render the same G-code visualizer output to the screenshot of the timelapse ;)
But I need to learn python first :(

#### What are the relevant tickets if any?
No tickets, just nice to have feature.

#### Screenshots (if appropriate)

#### Further notes
