### PR TITLE
print() uses file=, not stream= -- fix that, fix the error

### DIFF
--- a/src/octoprint/daemon.py
+++ b/src/octoprint/daemon.py
@@ -172,4 +172,4 @@ class Daemon:
 
 	@classmethod
 	def error(cls, line):
-		print(line, stream=sys.stderr)
+		print(line, file=sys.stderr)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Fix error resulting from passing stream= to print() - - print() actually takes file=. This results in a crash rather than a graceful exit when there's an error in the daemonizing process.

#### How was it tested? How can it be tested by the reviewer?

...I caused an error. =P Tried starting the daemon a second time when it was already running, got the error message rather than a stack trace.

#### Any background context you want to provide?

Nope.

#### What are the relevant tickets if any?

None.

#### Screenshots (if appropriate)

Not appropriate.

#### Further notes

No further notes.