### PR TITLE
Adjust output of values() classmethod to not include function itself

### DIFF
--- a/src/octoprint/printer/profile.py
+++ b/src/octoprint/printer/profile.py
@@ -34,7 +34,7 @@ class BedTypes(object):
 
 	@classmethod
 	def values(cls):
-		return [getattr(cls, name) for name in cls.__dict__ if not (name.startswith("__") or name="values")]
+		return [getattr(cls, name) for name in cls.__dict__ if not (name.startswith("__") or name == "values")]
 
 class BedOrigin(object):
 	LOWERLEFT = "lowerleft"
@@ -42,7 +42,7 @@ class BedOrigin(object):
 
 	@classmethod
 	def values(cls):
-		return [getattr(cls, name) for name in cls.__dict__ if not (name.startswith("__") or name="values")]
+		return [getattr(cls, name) for name in cls.__dict__ if not (name.startswith("__") or name == "values")]
 
 class PrinterProfileManager(object):
 	"""

--- a/src/octoprint/printer/profile.py
+++ b/src/octoprint/printer/profile.py
@@ -34,7 +34,7 @@ class BedTypes(object):
 
 	@classmethod
 	def values(cls):
-		return [getattr(cls, name) for name in cls.__dict__ if not name.startswith("__")]
+		return [getattr(cls, name) for name in cls.__dict__ if not (name.startswith("__") or name="values")]
 
 class BedOrigin(object):
 	LOWERLEFT = "lowerleft"
@@ -42,7 +42,7 @@ class BedOrigin(object):
 
 	@classmethod
 	def values(cls):
-		return [getattr(cls, name) for name in cls.__dict__ if not name.startswith("__")]
+		return [getattr(cls, name) for name in cls.__dict__ if not (name.startswith("__") or name="values")]
 
 class PrinterProfileManager(object):
 	"""


### PR DESCRIPTION

#### What does this PR do and why is it necessary?

The way values() works right now, the resulting array will also return itself. This isn't really a problem here, but if someone takes this function as a guide (like me) they can run into problems when iterating over the returned array, as it contains an element representing "values()" itself. As such, the change is more of a cosmetic nature, but since the fix is trivial I feel it makes sense.
#### How was it tested? How can it be tested by the reviewer?

In the plug-in I am currently developing, adjusting the output this way yields the expected result array.
#### Any background context you want to provide?
#### What are the relevant tickets if any?
#### Screenshots (if appropriate)
#### Further notes

Another approach would be make use of the inspect package and replace name="values" with inspect.ismethod(name). This would also cover cases where other functions are added to the two classes that should be excluded in the values() call.
