### PR TITLE
Fixed Cura plugin's get_pos_x/y returning the wrong value when self._…

### DIFF
--- a/src/octoprint/plugins/cura/profile.py
+++ b/src/octoprint/plugins/cura/profile.py
@@ -835,7 +835,7 @@ class Profile(object):
 		return 1
 
 	def get_pos_x(self):
-		if self._posX:
+		if self._posX is not None:
 			try:
 				return int(float(self._posX))
 			except ValueError:
@@ -844,7 +844,7 @@ class Profile(object):
 		return int(self.get_float("machine_width") / 2.0 ) if not self.get_boolean("machine_center_is_zero") else 0.0
 
 	def get_pos_y(self):
-		if self._posY:
+		if self._posY is not None:
 			try:
 				return int(float(self._posY))
 			except ValueError:


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Fixes an issue in the Cura plugin that incorrectly sets the posx and posy Cura Engine parameters under certain circumstances.

#### How was it tested? How can it be tested by the reviewer?
This can be tested by setting the current printer profile's origin to lowerleft and passing a position parameter where X and/or Y is 0 to the Cura plugin's do_slice function. Then the resulting posx and posy Cura Engine parameters can be compared to their expected values to see how this PR resolves the issue.

#### Any background context you want to provide?
Python evaluates 0 as false, so the Cura plugin's get_pos_x/y functions will return machine_width/depth / 2 if self._posX/Y is 0. It should be returning the value of self._posX/Y when self._posX/Y is set to anything including 0. 

#### What are the relevant tickets if any?
None

#### Screenshots (if appropriate)
Not appropriate

#### Further notes
None