### PR TITLE
Fixed link to M33 Fio plugin page

### DIFF
--- a/_data/promo.yaml
+++ b/_data/promo.yaml
@@ -38,7 +38,7 @@
 
       * Collect **statistics** of your printer and print jobs via the [Print History](http://plugins.octoprint.org/plugins/printhistory/) or the [Printer Statistics](http://plugins.octoprint.org/plugins/stats/) plugin.
 
-      * Add **support for specific printers** like [Flashforge printers or older Makerbots](http://plugins.octoprint.org/plugins/gpx/) or the [Micro 3D printer](http://plugins.octoprint.org/plugins/m3dfio/).
+      * Add **support for specific printers** like [Flashforge printers or older Makerbots](http://plugins.octoprint.org/plugins/gpx/) or the [Micro 3D printer](http://plugins.octoprint.org/plugins/m33fio/).
 
 
     OctoPrint''s [official plugin repository](http://plugins.octoprint.org/) is integrated right within OctoPrint and installing a plugin is only


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Fixes URL for M33 Fio plugin

#### How was it tested? How can it be tested by the reviewer?
It can be tested by visiting the URL

#### Any background context you want to provide?
This resulted when I had to change the plugin's name from M3D Fio to M33 Fio.

#### What are the relevant tickets if any?
None

#### Screenshots (if appropriate)
Not appropriate

#### Further notes
None