### PR TITLE
Make M600 look like a tool change.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -74,6 +74,7 @@ date of first contribution):
   * [Mathias Rangel Wulff](https://github.com/mathiasrw)
   * [Clemens Niemeyer](https://github.com/clemniem)
   * ["I-am-me"](https://github.com/I-am-me)
+  * [Ryan Neufeld](https://github.com/ryanneufeld)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/static/gcodeviewer/js/Worker.js
+++ b/src/octoprint/static/gcodeviewer/js/Worker.js
@@ -267,6 +267,15 @@ var doParse = function () {
 
         var log = false;
 
+        if (/^(?:M600)/i.test(line)) {
+            console.log("Replacing M600 with tool change");
+            tool++
+            if (tool > 1) {
+                tool = 0;
+            }
+            line = "T" + tool;
+        }
+
         if (/^(?:G0|G1|G2|G3)\s/i.test(line)) {
             var args = line.split(/\s/);
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR detects the M600 command used by Prusa flavored firmwares and replaces the command with either a T0 or T1 command. This allows users of Prusa's Colorprint utility to visualize when in the print they can expect a filament change to take place.

#### How was it tested? How can it be tested by the reviewer?

I tested by loading this [gcode](https://gist.github.com/ryanneufeld/419f5b7e0ce9ea759bbb2abf3f2f7e93) file and using the slider on the right to watch the colors change as I jogged through the layers.

In short, it was manually tested.


