### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM python:2.7.12
 EXPOSE 5000
 
-RUN git clone https://github.com/foosel/OctoPrint.git /opt/octoprint
-#ADD * /opt/octoprint/
+ADD ./ /opt/octoprint/
 RUN cd /opt/octoprint && python setup.py install
 
 CMD ["octoprint", "--iknowwhatimdoing"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:2.7.12
+EXPOSE 5000
+
+RUN git clone https://github.com/foosel/OctoPrint.git /opt/octoprint
+#ADD * /opt/octoprint/
+RUN cd /opt/octoprint && python setup.py install
+
+CMD ["octoprint", "--iknowwhatimdoing"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:2.7.12
 EXPOSE 5000
+VOLUME /root/.octoprint
+
+RUN  wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-32bit-static.tar.xz && mkdir -p /opt/ffmpeg && tar xvf ffmpeg.tar.xz -C /opt/ffmpeg --strip-components=1
 
 ADD ./ /opt/octoprint/
 RUN cd /opt/octoprint && python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,23 @@
 FROM python:2.7.12
 EXPOSE 5000
-VOLUME /root/.octoprint
+VOLUME /user/octoprint/.octoprint
 
-RUN  wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-32bit-static.tar.xz && mkdir -p /opt/ffmpeg && tar xvf ffmpeg.tar.xz -C /opt/ffmpeg --strip-components=1
+WORKDIR /opt/octoprint
 
+#install ffmpeg
+RUN  wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-32bit-static.tar.xz \
+	&& mkdir -p /opt/ffmpeg \
+	&& tar xvf ffmpeg.tar.xz -C /opt/ffmpeg --strip-components=1
+
+#Copy repo to /opt/octoprint
 ADD ./ /opt/octoprint/
-RUN cd /opt/octoprint && python setup.py install
 
-CMD ["octoprint", "--iknowwhatimdoing"]
+#Perform installation
+RUN virtualenv venv \
+	&& ./venv/bin/python setup.py install
+
+#Create an octoprint user
+RUN useradd -ms /bin/bash octoprint
+USER octoprint
+
+CMD ["/opt/octoprint/venv/bin/octoprint"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  octoprint:
+    build: .
+    image: gaetancollaud/octoprint
+    container_name: octoprint
+    ports:
+      - 5000:5000
+    devices:
+      - /dev/ttyACM0:/dev/ttyS0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: octoprint
     ports:
       - 5000:5000
-    devices:
-      - /dev/ttyACM0:/dev/ttyS0
+#    devices:
+#      - /dev/ttyACM0:/dev/ttyS0
 #    volumes:
 #      - /yourDataFolder/octoprint:/root/.octoprint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,5 @@ services:
       - 5000:5000
     devices:
       - /dev/ttyACM0:/dev/ttyS0
+#    volumes:
+#      - /yourDataFolder/octoprint:/root/.octoprint


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR add the docker description files to run Octoprint in a docker environment.

#### How was it tested? How can it be tested by the reviewer?

I build the image and tested in with my 3D printer (Ultimaker).
I printed a file successfully and generated a timelapse.
I destroyed and created a new container using the same volume and everything came back (configuration, uploaded files and timelpases).

#### Any background context you want to provide?

Using docker can reduce the setup time. If someone just want to give it a try he can run OctoPrint very quickly without going through the installation (I also included ffmpeg for timelapses).

Additionally, using container can help using octoprint with multiple printers at the same time on the same machine. See the example in the docker-compose file, I mapped /dev/ttyACM0 to /dev/ttyS0 and I use the port 5000. But imagine you have multiple printers, you can for instance:
* run one container using /dev/ttyACM0 on port 5000
* run one container using /dev/ttyACM1 on port 5001
* etc.

Additionally using proxy server like [traefik](https://traefik.io) you can easily add domain name to your printer. For instance:
* /dev/ttyACM0 is ultimaker1.my-fablab.ch
* /dev/ttyACM1 is ultimaker2.my-fablab.ch
* etc.

#### What are the relevant tickets if any?

None

#### Screenshots (if appropriate)

No screenshots

#### Further notes

Currently I'm using my personal dockerhub account ! Feel free to change it to yours.

Building and pushing the image to dockerhub:
```
docker-compose build
docker-compose push
```
Running the image using docker compose
```
docker-compose up
```
Running the image without docker compose
```
docker run -it --volume /my/config/folder:/root/.octoprint --device=/dev/ttyACM0:/dev/ttyS0 -p 5000:5000 gaetancollaud/octoprint
```
