### PR TITLE
Make the print cancel confirmation dialog box optional.

### DIFF
--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -125,7 +125,8 @@ def getSettings():
 			"pollWatched": s.getBoolean(["feature", "pollWatched"]),
 			"ignoreIdenticalResends": s.getBoolean(["feature", "ignoreIdenticalResends"]),
 			"modelSizeDetection": s.getBoolean(["feature", "modelSizeDetection"]),
-			"firmwareDetection": s.getBoolean(["feature", "firmwareDetection"])
+			"firmwareDetection": s.getBoolean(["feature", "firmwareDetection"]),
+			"printCancelConfirmation": s.getBoolean(["feature", "printCancelConfirmation"])
 		},
 		"serial": {
 			"port": connectionOptions["portPreference"],
@@ -309,6 +310,7 @@ def _saveSettings(data):
 		if "ignoreIdenticalResends" in data["feature"]: s.setBoolean(["feature", "ignoreIdenticalResends"], data["feature"]["ignoreIdenticalResends"])
 		if "modelSizeDetection" in data["feature"]: s.setBoolean(["feature", "modelSizeDetection"], data["feature"]["modelSizeDetection"])
 		if "firmwareDetection" in data["feature"]: s.setBoolean(["feature", "firmwareDetection"], data["feature"]["firmwareDetection"])
+		if "printCancelConfirmation" in data["feature"]: s.setBoolean(["feature", "printCancelConfirmation"], data["feature"]["printCancelConfirmation"])
 
 	if "serial" in data.keys():
 		if "autoconnect" in data["serial"].keys(): s.setBoolean(["serial", "autoconnect"], data["serial"]["autoconnect"])

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -200,7 +200,8 @@ default_settings = {
 		"identicalResendsCountdown": 7,
 		"supportFAsCommand": False,
 		"modelSizeDetection": True,
-		"firmwareDetection": True
+		"firmwareDetection": True,
+		"printCancelConfirmation": True
 	},
 	"folder": {
 		"uploads": None,

--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -3,6 +3,7 @@ $(function() {
         var self = this;
 
         self.loginState = parameters[0];
+        self.settings = parameters[1];
 
         self.stateString = ko.observable(undefined);
         self.isErrorOrClosed = ko.observable(undefined);
@@ -288,18 +289,22 @@ $(function() {
         };
 
         self.cancel = function() {
-            showConfirmationDialog({
-                message: gettext("This will cancel your print."),
-                onproceed: function() {
-                    OctoPrint.job.cancel();
-                }
-            });            
+            if (!self.settings.feature_printCancelConfirmation()) {
+                OctoPrint.job.cancel();
+            } else {
+                showConfirmationDialog({
+                    message: gettext("This will cancel your print."),
+                    onproceed: function() {
+                        OctoPrint.job.cancel();
+                    }
+                });
+            };            
         };
     }
 
     OCTOPRINT_VIEWMODELS.push([
         PrinterStateViewModel,
-        ["loginStateViewModel"],
+        ["loginStateViewModel", "settingsViewModel"],
         ["#state_wrapper", "#drop_overlay"]
     ]);
 });

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -138,6 +138,7 @@ $(function() {
         self.feature_ignoreIdenticalResends = ko.observable(undefined);
         self.feature_modelSizeDetection = ko.observable(undefined);
         self.feature_firmwareDetection = ko.observable(undefined);
+        self.feature_printCancelConfirmation = ko.observable(undefined);
 
         self.serial_port = ko.observable();
         self.serial_baudrate = ko.observable();

--- a/src/octoprint/templates/dialogs/settings/features.jinja2
+++ b/src/octoprint/templates/dialogs/settings/features.jinja2
@@ -34,7 +34,13 @@
             </label>
         </div>
     </div>
-
+    <div class="control-group">
+        <div class="controls">
+            <label class="checkbox">
+                <input type="checkbox" data-bind="checked: feature_printCancelConfirmation" id="settings-printCancelConfirmation"> {{ _('Confirm before cancelling a print') }}
+            </label>
+        </div>
+    </div>
     <div class="control-group">
         <div class="controls">
             <label class="checkbox">


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Adds a feature checkbox to disable the cancel confirmation dialog box and fulfills the feature request https://github.com/foosel/OctoPrint/issues/1638

#### How was it tested? How can it be tested by the reviewer?

Octoprint installed under a windows 7 environment with Python 2.7.12 (v2.7.12:d33e0cf91556, Jun 27 2016, 15:19:22) [MSC v.1500 32 bit (
Intel)] on win32
Browsers used to test were Google Chrome for Android and Chrome for Windows 7/10 and Firefox for windows 10 using octoprint's virtual printer to start a test print, cancel a test print and observe whether the cancel confirmation dialog box appearance corresponds to the option being enabled or disabled.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

Fulfilling a feature request: https://github.com/foosel/OctoPrint/issues/1638

#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/9030085/21102557/60107736-c0ca-11e6-913d-a1dc64cc5b04.png)


#### Further notes

Making the print cancel confirmation dialog box optional