### PR TITLE
Include LSB above first use in init.d script

### DIFF
--- a/scripts/octoprint.init
+++ b/scripts/octoprint.init
@@ -25,6 +25,10 @@ SCRIPTNAME=/etc/init.d/$PKGNAME
 # Read configuration variable file if it is present
 [ -r /etc/default/$PKGNAME ] && . /etc/default/$PKGNAME
 
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
+. /lib/lsb/init-functions
+
 # Exit if the DAEMON is not set
 if [ -z "$DAEMON" ]
 then
@@ -37,10 +41,6 @@ fi
 
 # Load the VERBOSE setting and other rcS variables
 [ -f /etc/default/rcS ] && . /etc/default/rcS
-
-# Define LSB log_* functions.
-# Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
-. /lib/lsb/init-functions
 
 if [ -z "$START" -o "$START" != "yes" ]
 then


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Fixes a late inclusion of the LSB functions in Octoprint's `init.d` script so that the include is executed before the first call to "log_warning_msg"

#### How was it tested? How can it be tested by the reviewer?
Follow the repro steps described in [Issue 1653](https://github.com/foosel/OctoPrint/issues/1653).

#### Any background context you want to provide?
Not sure why the init.d script only barfs on the most recent BBB image; OctoPrint v1.3.0 worked fine on an old image it was running from 2 years ago (which I only updated because the GPG keys of the old APT repository expired).

#### What are the relevant tickets if any?

[Issue 1653](https://github.com/foosel/OctoPrint/issues/1653)