### PR TITLE
Octoprint /dev/ttyS* addition

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -74,6 +74,7 @@ date of first contribution):
   * [Mathias Rangel Wulff](https://github.com/mathiasrw)
   * [Clemens Niemeyer](https://github.com/clemniem)
   * ["I-am-me"](https://github.com/I-am-me)
+  * [J-J Heinonen](https://github.com/jammi)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -144,6 +144,7 @@ def serialList():
 			   + glob.glob("/dev/tty.usb*") \
 			   + glob.glob("/dev/cu.*") \
 			   + glob.glob("/dev/cuaU*") \
+			   + glob.glob("/dev/ttyS*") \
 			   + glob.glob("/dev/rfcomm*")
 
 	additionalPorts = settings().get(["serial", "additionalPorts"])


### PR DESCRIPTION
OctoPrint wasn't looking for /dev/ttyS* devices, so I added them. Tested on CubieBoard vs a Melzi-based printer.