### PR TITLE
Fix issue in getting file metadata after slicing

### DIFF
--- a/src/octoprint/plugins/cura/__init__.py
+++ b/src/octoprint/plugins/cura/__init__.py
@@ -372,10 +372,12 @@ class CuraPlugin(octoprint.plugin.SlicerPlugin,
 									analysis = dict()
 								if not "filament" in analysis:
 									analysis["filament"] = dict()
-								if not tool_key in analysis["filament"]:
+								if not tool_key in analysis["filament"] and filament > 0:
 									analysis["filament"][tool_key] = dict()
 
-								if profile.get_float("filament_diameter") != None:
+								profile = Profile(self._load_profile(profile_path), printer_profile, posX, posY)
+
+								if profile.get_float("filament_diameter") != None and filament > 0:
 									if profile.get("gcode_flavor") == GcodeFlavors.ULTIGCODE or profile.get("gcode_flavor") == GcodeFlavors.REPRAP_VOLUME:
 										analysis["filament"][tool_key] = _get_usage_from_volume(filament, profile.get_float("filament_diameter"))
 									else:


### PR DESCRIPTION
This fixes the issue that there were no informations about filament
usage in metadata after slicing with cura plugin. Trying to call
profile.get_float("filament_diameter") ended in en exception with
message " 'module' object has no attribute 'get_float' ". So i defined
profile before using profile and now it works.
See issue #1685
Also inserted a check to determine if filament usage is > 0 to exclude tools with no filament usage in metadata.