### PR TITLE
Changed old comments to not claim a method does more than it really does

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -1545,7 +1545,7 @@ class MachineCom(object):
 
 	def _poll_temperature(self):
 		"""
-		Polls the temperature after the temperature timeout, re-enqueues itself.
+		Polls the temperature.
 
 		If the printer is not operational, closing the connection, not printing from sd, busy with a long running
 		command or heating, no poll will be done.
@@ -1556,7 +1556,7 @@ class MachineCom(object):
 
 	def _poll_sd_status(self):
 		"""
-		Polls the sd printing status after the sd status timeout, re-enqueues itself.
+		Polls the sd printing status.
 
 		If the printer is not operational, closing the connection, not printing from sd, busy with a long running
 		command or heating, no poll will be done.


### PR DESCRIPTION
Because comments are there to clear up confusion, might as well start here.

I just started looking through OctoPrint source and noticed this comment seemed to not be true anymore so I thought I'd fix it.  poll_temperature and poll_sd_status are called by a RepeatedTimer now, the methods don't re-enqueue themselves.