### PR TITLE
Simplified install process on Mac

### DIFF
--- a/THIRDPARTYLICENSES.md
+++ b/THIRDPARTYLICENSES.md
@@ -55,3 +55,4 @@
   * [SockJS-Tornado](http://github.com/mrjoes/sockjs-tornado/): MIT
   * [Tornado](http://www.tornadoweb.org/): Apache License 2.0
   * [watchdog](http://github.com/gorakhargosh/watchdog): Apache License 2.0
+  * [appdirs](http://github.com/ActiveState/appdirs): MIT

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -145,7 +145,6 @@ You'll need a user account with administrator privileges.
        cd OctoPrint
        virtualenv venv
        source venv/bin/activate
-       pip install -U pyobjc
        pip install -e .[develop]
 
 You can then start OctoPrint via ``~/devel/OctoPrint/venv/bin/octoprint`` or just ``octoprint`` if you activated the virtual

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,9 @@ INSTALL_REQUIRES = [
 	"websocket-client>=0.40,<0.41"
 ]
 
+if sys.platform == "darwin":
+	INSTALL_REQUIRES.append("appdirs>=1.4.0")
+
 # Additional requirements for optional install options
 EXTRA_REQUIRES = dict(
 	# Dependencies for developing OctoPrint

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -1487,12 +1487,8 @@ class Settings(object):
 def _default_basedir(applicationName):
 	# taken from http://stackoverflow.com/questions/1084697/how-do-i-store-desktop-application-data-in-a-cross-platform-way-for-python
 	if sys.platform == "darwin":
-		from AppKit import NSSearchPathForDirectoriesInDomains
-		# http://developer.apple.com/DOCUMENTATION/Cocoa/Reference/Foundation/Miscellaneous/Foundation_Functions/Reference/reference.html#//apple_ref/c/func/NSSearchPathForDirectoriesInDomains
-		# NSApplicationSupportDirectory = 14
-		# NSUserDomainMask = 1
-		# True for expanding the tilde into a fully qualified path
-		return os.path.join(NSSearchPathForDirectoriesInDomains(14, 1, True)[0], applicationName)
+		from appdirs import *
+		return user_data_dir(applicationName, "")
 	elif sys.platform == "win32":
 		return os.path.join(os.environ["APPDATA"], applicationName)
 	else:


### PR DESCRIPTION
I was trying to install OctoPrint on macOS by following the steps in the README when I ran into the problem "No module named AppKit", the same as here: https://github.com/foosel/OctoPrint/issues/1565.  It turns out OctoPrint was using NSSearchPathForDirectoriesInDomains from AppKit to get the Application Support directory.  This required an extra step of installing pyobjc.

However, pyobjc isn't that easy to install now because of System Integrity Protection (http://apple.stackexchange.com/questions/209572/how-to-use-pip-after-the-os-x-el-capitan-upgrade).  Hopefully Mac users could get OctoPrint set up without this extra step at all.  So I decided to simplify and use appdirs (https://pypi.python.org/pypi/appdirs) instead.  This can be installed easily in setup.py and does exactly what we need by finding the same Application Support directory.

After this change I was able to install and run OctoPrint on my Mac.