### PR TITLE
Add systemd unit file

### DIFF
--- a/scripts/octoprint.service
+++ b/scripts/octoprint.service
@@ -1,0 +1,52 @@
+# Install this unit file with:
+#
+#   sudo cp octoprint.service /etc/systemd/system
+#   sudo systemctl daemon-reload
+#
+# Configure the service to start at boot, and then start it with:
+#
+#   sudo systemctl enable octoprint
+#   sudo systemctl start octoprint
+#
+# Optionally, verify that it started correctly with:
+#
+#   sudo systemctl status octoprint
+#
+# OctoPrint's log messages printed on stdout/stderr can be obtained using:
+#
+#   sudo journalctl -u octoprint
+#
+[Unit]
+Description=OctoPrint - the snappy web interface for your 3D printer
+
+[Service]
+# Default environment, for compatibility with scripts/octoprint.init
+Environment=PORT=5000
+Environment=BASEDIR=/home/pi/.octoprint
+Environment=CONFIGFILE=/home/pi/.octoprint/config.yaml
+# Optional daemon arguments, e.g. `--host 127.0.0.1`
+Environment="DAEMON_ARGS="
+
+# The above defaults can be overridden by placing the environment variable
+# expressions in the optional environment file /etc/defaults/octoprint
+# Docs: https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=
+EnvironmentFile=-/etc/default/octoprint
+
+# Debian Jessie does not support `sudo systemctl edit octoprint`, so to
+# override the below settings, do:
+#   sudo mkdir /etc/systemd/system/octoprint.service.d
+#   sudo nano /etc/systemd/system/octoprint.service.d/override.conf
+# In this file, add a `[Service]` section header and put the updated
+# configuration below that header.
+
+User=pi
+Group=pi
+
+# Process priority, 0 here will result in a priority 20 process.
+# -2 ensures Octoprint has a slight priority over user processes.
+Nice=-2
+
+ExecStart=/home/pi/OctoPrint/venv/bin/octoprint serve --basedir ${BASEDIR} --config ${CONFIGFILE} --port ${PORT} $DAEMON_ARGS"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR adds a systemd unit file to allow OctoPrint to be started at boot time in a modern Linux distribution that runs the systemd init system.  The unit file's defaults are suitable for the instructions provided in [Setup on a Raspberry Pi running Raspbian](https://github.com/foosel/OctoPrint/wiki/Setup-on-a-Raspberry-Pi-running-Raspbian)

It tries to be backwards compatible with the existing init script with respect to envs defined in`/etc/default/octoprint`, although a few of them (`OCTOPRINT_USER`, `DAEMON`, `NICE` and `UMASK`) were not possible to support in the unit file.  See the unit file for instructions on howto override these.

OctoPrint already comes with a SysV and Debian-style init script and configuration template.  These work fine, even in a systemd world.  But since most modern Linux distributions have moved over to systemd, I figured a systemd unit file would be a more proper way of doing things moving forward.

That way new OctoPrint users, some of who perhaps come in contact with Linux for the first time, don't unnecessarily get "exposed" to the old (and in the future, perhaps deprecated) way of adding boot services,  but instead get to learn the modern way with `systemctl` (and `journalctl` for debugging) right from the start.

#### How was it tested? How can it be tested by the reviewer?

```
# Disable old OctoPrint init script
sudo service octoprint stop
sudo update-rc.d -f octoprint remove || true
sudo mv /etc/init.d/octoprint /etc/init.d/octoprint-old || true
sudo mv /etc/default/octoprint /etc/default/octoprint-old || true

# Install new OctoPrint init script
sudo cp scripts/octoprint.service /etc/systemd/system
sudo systemctl daemon-reload
sudo systemctl enable octoprint
sudo systemctl start octoprint
sudo systemctl status octoprint
sudo journalctl -u octoprint
ps auxw|grep -i octoprint

# Test change port via /etc/default/octoprint
echo PORT=1234 |sudo tee -a /etc/default/octoprint
sudo systemctl restart octoprint
ps auxw|grep -i octoprint
```

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

- Debian Jessie (8.0) supports systemd
- Raspbian Jessie was released in sept, 2015
- The older Debian Wheezy (7.0) and Raspbian Wheezy does not support systemd

Like the author of the current init script, some helpful instructions are provided at the top of the file. They may serve as a starting point if the instructions in the [wiki](https://github.com/foosel/OctoPrint/wiki/Setup-on-a-Raspberry-Pi-running-Raspbian#automatic-start-up) should be updated aswell.