### PR TITLE
Update index.jinja2

### DIFF
--- a/src/octoprint/templates/index.jinja2
+++ b/src/octoprint/templates/index.jinja2
@@ -19,7 +19,7 @@
         <div class="page-container">
             <div id="navbar" class="navbar navbar-static-top">
                 <div class="navbar-inner" data-bind="css: appearanceClasses">
-                    <div class="container">
+                    <div class="container-fluid">
                         <a class="brand" href="#"> <span data-bind="text: appearance.brand">OctoPrint</span></a>
                         <div class="nav-collapse">
                             <!-- Navbar -->


### PR DESCRIPTION
Many plugins will add informations in the navbar, resulting of a degraded appearance. Using .container-fluid instead of .container would allow to show more data into the navbar, since many screens nowadays have a larger width.
