### PR TITLE
Add sameDevice to api/slicing API

### DIFF
--- a/src/octoprint/server/api/slicing.py
+++ b/src/octoprint/server/api/slicing.py
@@ -72,6 +72,7 @@ def slicingListAll():
 			result[slicer] = dict(
 				key=slicer,
 				displayName=slicer_impl.get_slicer_properties()["name"],
+				sameDevice=slicer_impl.get_slicer_properties()["same_device"],
 				default=default_slicer == slicer,
 				configured=slicer_impl.is_slicer_configured(),
 				profiles=_getSlicingProfilesData(slicer),


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Adds sameDevice to the slicing API so that the web client can know if the configured slicer runs locally or not.

A web client could display if slicing is currently possible only if it knows whether slicing is configured, if we're are printing/paused, and if the slicer is on the same device as the printer.  Of those, only the last one is unavailable.  With this PR, all are available.

#### How was it tested? How can it be tested by the reviewer?
Reload octoprint and watch network traffic and watch the JSON output from REST API to api/slicing

#### Any background context you want to provide?
This is the plugin that initiated the change: https://github.com/kennethjiang/OctoPrint-Slicer/pull/29