### PR TITLE
add sameDevice to SlicingViewModel

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/slicing.js
+++ b/src/octoprint/static/js/app/viewmodels/slicing.js
@@ -204,7 +204,8 @@ $(function() {
                     name: name,
                     configured: slicer.configured,
                     sourceExtensions: slicer.extensions.source,
-                    destinationExtensions: slicer.extensions.destination
+                    destinationExtensions: slicer.extensions.destination,
+                    sameDevice: slicer.sameDevice
                 };
                 self.slicers.push(props);
             });


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Adds sameDevice to the SlicingViewModel.  It was already added to the API in https://github.com/foosel/OctoPrint/pull/1748 but now it needs to be part of the view model.

#### How was it tested? How can it be tested by the reviewer?

I listed the SlicingViewModel.slicers() in Chrome's development console before and after this change and saw that sameDevice is now listed for each slicer.
