### PR TITLE
UserSettings: crashed if overwrite an existing key with primitive value by same key with complex value. Also reduced number of calls to user.get_setting()

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -78,6 +78,7 @@ date of first contribution):
   * [Noah Martin](https://github.com/noahsmartin)
   * [Eyal Soha](https://github.com/eyal0)
   * [Greg Hulands](https://github.com/ghulands)
+  * [Andreas Werner](https://github.com/gallore)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/users.py
+++ b/src/octoprint/users.py
@@ -310,9 +310,8 @@ class FilebasedUserManager(UserManager):
 			raise UnknownUser(username)
 
 		user = self._users[username]
-		current = user.get_setting(key)
-		if not current or current != value:
-			old_value = user.get_setting(key)
+		old_value = user.get_setting(key)
+		if not old_value or old_value != value:
 			user.set_setting(key, value)
 			self._dirty = self._dirty or old_value != value
 			self._save()
@@ -548,7 +547,7 @@ class User(UserMixin):
 	def _get_setting(self, path):
 		s = self._settings
 		for p in path:
-			if p in s:
+			if isinstance(s, dict) and p in s:
 				s = s[p]
 			else:
 				return None
@@ -561,7 +560,7 @@ class User(UserMixin):
 				s[p] = dict()
 
 			if not isinstance(s[p], dict):
-				return False
+				s[p] = dict()
 
 			s = s[p]
 

--- a/tests/users/test_user.py
+++ b/tests/users/test_user.py
@@ -63,7 +63,9 @@ class UserTestCase(unittest.TestCase):
 		(["sub", "othersubkey"], "othersubvalue", dict(sub=dict(othersubkey="othersubvalue")), True),
 		("booleankey", True, dict(booleankey=True), True),
 		(["newsub", "newsubkey"], "newsubvalue", dict(newsub=dict(newsubkey="newsubvalue")), True),
-		(["sub", "subkey", "wontwork"], "wontwork", dict(), False)
+		# ["sub", "subkey"] is already existing and gets overwritten
+		(["sub", "subkey", "subsubkey"], "42", dict(sub=dict(subkey=dict(subsubkey="42"))), True),
+		(["sub"], "overwrite", dict(sub="overwrite"), True)
 	)
 	@ddt.unpack
 	def test_set_setting_string(self, key, value, update, expected_returnvalue):


### PR DESCRIPTION
UserSettings: crashed if overwrite an existing key with primitive value by same key with complex value. Also reduced number of calls to user.get_setting()

----

#### What does this PR do and why is it necessary?
See test. Second line crashes without this:
  File "/Users/andy/mrbeam/git/OctoPrint/src/octoprint/users.py", line 481, in _get_setting
    if p in s:
TypeError: argument of type 'int' is not iterable

#### How was it tested? How can it be tested by the reviewer?
self._user_manager.changeUserSetting(username, ['mrBeam'], 42)
self._user_manager.changeUserSetting(username, ['mrBeam', 'anotherLevel'], 3.14159)

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
