### PR TITLE
Add confirm dialog to timelapse deletion

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/timelapse.js
+++ b/src/octoprint/static/js/app/viewmodels/timelapse.js
@@ -207,7 +207,7 @@ $(function() {
  					.done(self.requestData);
             } else {
                 showConfirmationDialog({
-                    message: gettext("This will cancel your print."),
+                    message: gettext("Delete selected timelapse?"),
                     cancel: gettext("No"),
                     proceed: gettext("Yes"),
                     onproceed: function() {

--- a/src/octoprint/static/js/app/viewmodels/timelapse.js
+++ b/src/octoprint/static/js/app/viewmodels/timelapse.js
@@ -18,6 +18,7 @@ $(function() {
         self.timelapseFps = ko.observable(self.defaultFps);
         self.timelapseRetractionZHop = ko.observable(self.defaultRetractionZHop);
         self.timelapseCapturePostRoll = ko.observable(self.defaultCapturePostRoll);
+        self.timelapseDeleteConfirm = ko.observable(true);
 
         self.persist = ko.observable(false);
         self.isDirty = ko.observable(false);
@@ -201,15 +202,20 @@ $(function() {
         };
 
         self.removeFile = function(filename) {
-			showConfirmationDialog({
-                message: gettext("Delete selected timelapse?"),
-                cancel: gettext("No"),
-                proceed: gettext("Yes"),
-                onproceed: function() {
-                    OctoPrint.timelapse.delete(filename)
-						.done(self.requestData);
-				}
-			});
+			if (!self.timelapseDeleteConfirm()) {
+                OctoPrint.timelapse.delete(filename)
+ 					.done(self.requestData);
+            } else {
+                showConfirmationDialog({
+                    message: gettext("This will cancel your print."),
+                    cancel: gettext("No"),
+                    proceed: gettext("Yes"),
+                    onproceed: function() {
+                        OctoPrint.timelapse.delete(filename)
+ 							.done(self.requestData);
+                    }
+                });
+            }
         };
 
         self.removeUnrendered = function(name) {

--- a/src/octoprint/static/js/app/viewmodels/timelapse.js
+++ b/src/octoprint/static/js/app/viewmodels/timelapse.js
@@ -201,8 +201,15 @@ $(function() {
         };
 
         self.removeFile = function(filename) {
-            OctoPrint.timelapse.delete(filename)
-                .done(self.requestData);
+			showConfirmationDialog({
+                message: gettext("Delete selected timelapse?"),
+                cancel: gettext("No"),
+                proceed: gettext("Yes"),
+                onproceed: function() {
+                    OctoPrint.timelapse.delete(filename)
+						.done(self.requestData);
+				}
+			});
         };
 
         self.removeUnrendered = function(name) {

--- a/src/octoprint/templates/tabs/timelapse.jinja2
+++ b/src/octoprint/templates/tabs/timelapse.jinja2
@@ -64,6 +64,12 @@
 
 <div class="pull-right">
     <small>{{ _('Sort by') }}: <a href="javascript:void(0)" data-bind="click: function() { listHelper.changeSorting('name'); }">{{ _('Name') }} ({{ _('ascending') }})</a> | <a href="javascript:void(0)" data-bind="click: function() { listHelper.changeSorting('creation'); }">{{ _('Creation date') }} ({{ _('descending') }})</a> | <a href="javascript:void(0)" data-bind="click: function() { listHelper.changeSorting('size'); }">{{ _('Size') }} ({{ _('descending') }})</a></small>
+    </br>
+    <div class="pull-right" data-bind="visible: loginState.isAdmin">
+        <label class="checkbox">
+            <input type="checkbox" data-bind="checked: timelapseDeleteConfirm"> {{ _('Confirm Delete') }}
+        </label>
+    </div>
 </div>
 <table class="table table-striped table-hover table-condensed table-hover" id="timelapse_files">
     <thead>


### PR DESCRIPTION
**What does this PR do and why is it necessary?**

Fulfils a feature request: #1798 to add a confirmation dialog when deleting a timelapse to prevent accidental deletion.

**How was it tested? How can it be tested by the reviewer?**

Create a timelapse video via the usual methods, or an empty text file named "test.mpg" and hit the delete icon in the timelapse tab, observe there is a dialog confirming the deletion and that pressing "yes" deletes the file while pressing "no" does not.

**Any background context you want to provide?**

I've seen this request a couple of times and been a victim of accidental deletion myself, figured I'd have at it.

**What are the relevant tickets if any?**

#1798

**Screenshots (if appropriate)**

![image](https://cloud.githubusercontent.com/assets/9030085/23607977/db5063f0-02b2-11e7-98b1-e3425319fc80.png)

