### PR TITLE
Only reset scroll position for settings content. (Fixes #1812)

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -814,7 +814,7 @@ $(function() {
         };
 
         self._resetScrollPosition = function() {
-            $('.scrollable', self.settingsDialog).scrollTop(0);
+            $('#settings_dialog_content', self.settingsDialog).scrollTop(0);
         };
 
         self.selectTab = function(tab) {


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Fixes #1812 by only resetting scroll position for `#settings_dialog_content` instead of `.scrollable`

#### How was it tested? How can it be tested by the reviewer?
See #1812 

#### Any background context you want to provide?

#### What are the relevant tickets if any?
#1812 

#### Screenshots (if appropriate)

#### Further notes
