### PR TITLE
Fix/celcius typo

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -79,6 +79,7 @@ date of first contribution):
   * [Greg Hulands](https://github.com/ghulands)
   * [Andreas Werner](https://github.com/gallore)
   * [Shawn Bruce](https://github.com/kantlivelong)
+  * [Claudiu Ceia] (https://github.com/ClaudiuCeia)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/templates/dialogs/settings/appearance.jinja2
+++ b/src/octoprint/templates/dialogs/settings/appearance.jinja2
@@ -39,7 +39,7 @@
     <div class="control-group">
         <div class="controls">
             <label class="checkbox">
-                <input type="checkbox" data-bind="checked: appearance_showFahrenheitAlso" id="settings-appearanceShowFahrenheitAlso"> {{ _('Show temperatures in Fahrenheit as well as Celcius') }}
+                <input type="checkbox" data-bind="checked: appearance_showFahrenheitAlso" id="settings-appearanceShowFahrenheitAlso"> {{ _('Show temperatures in Fahrenheit as well as Celsius') }}
             </label>
         </div>
     </div>

--- a/src/octoprint/translations/de/LC_MESSAGES/messages.po
+++ b/src/octoprint/translations/de/LC_MESSAGES/messages.po
@@ -2852,7 +2852,7 @@ msgstr ""
 "überschrieben sind."
 
 #: src/octoprint/templates/dialogs/settings/appearance.jinja2:42
-msgid "Show temperatures in Fahrenheit as well as Celcius"
+msgid "Show temperatures in Fahrenheit as well as Celsius"
 msgstr "Temperaturen sowohl in Fahrenheit als auch Celsius anzeigen"
 
 #: src/octoprint/templates/dialogs/settings/appearance.jinja2:51

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -2852,7 +2852,7 @@ msgstr ""
 "überschrieben sind."
 
 #: src/octoprint/templates/dialogs/settings/appearance.jinja2:42
-msgid "Show temperatures in Fahrenheit as well as Celcius"
+msgid "Show temperatures in Fahrenheit as well as Celsius"
 msgstr "Temperaturen sowohl in Fahrenheit als auch Celsius anzeigen"
 
 #: src/octoprint/templates/dialogs/settings/appearance.jinja2:51

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -2570,7 +2570,7 @@ msgid ""
 msgstr ""
 
 #: src/octoprint/templates/dialogs/settings/appearance.jinja2:42
-msgid "Show temperatures in Fahrenheit as well as Celcius"
+msgid "Show temperatures in Fahrenheit as well as Celsius"
 msgstr ""
 
 #: src/octoprint/templates/dialogs/settings/appearance.jinja2:51


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This PR fixes a small typo in the Appearance tab of the Settings modal.

#### How was it tested? How can it be tested by the reviewer?
Just run OctoPrint and check that the last checkbox in the Appearance tab now says "Celsius" instead of "Celcius"

#### Any background context you want to provide?
Just a pet peeve of mine and thought I'd fix it.

#### What are the relevant tickets if any?
N/A
#### Screenshots (if appropriate)
![download](https://cloud.githubusercontent.com/assets/22706412/24072274/4b88efb4-0bed-11e7-8f44-6e456cdc1b1d.png)

#### Further notes
