### PR TITLE
Add octoprint.timelapse.capture.[pre/post] hooks

### DIFF
--- a/docs/plugins/hooks.rst
+++ b/docs/plugins/hooks.rst
@@ -922,3 +922,35 @@ octoprint.ui.web.templatetypes
    :param dict template_sorting: read-only dictionary of currently configured template sorting specifications
    :return: a list of 3-tuples (template type, rule, sorting spec)
    :rtype: list
+
+.. _sec-plugins-hook-timelapse-capture-pre:
+
+octoprint.timelapse.capture.pre
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. py:function:: capture_pre_hook(filename)
+
+   Perform specific actions prior to capturing a timelapse frame.
+
+   ``filename`` will be the future path of the frame to be saved.
+
+   :param str filename: The future path of the frame to be saved.
+   :return: None
+   :rtype: None
+
+.. _sec-plugins-hook-timelapse-capture-post:
+
+octoprint.timelapse.capture.post
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. py:function:: capture_post_hook(filename, success)
+
+   Perform specific actions after capturing a timelapse frame.
+
+   ``filename`` will be the path of the frame that should have been saved.
+   ``sucesss`` indicates whether the capture was successful or not.
+
+   :param str filename: The path of the frame that should have been saved.
+   :param boolean success: Indicates whether the capture was successful or not.
+   :return: None
+   :rtype: None

--- a/docs/plugins/hooks.rst
+++ b/docs/plugins/hooks.rst
@@ -926,7 +926,7 @@ octoprint.ui.web.templatetypes
 .. _sec-plugins-hook-timelapse-capture-pre:
 
 octoprint.timelapse.capture.pre
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. py:function:: capture_pre_hook(filename)
 
@@ -941,7 +941,7 @@ octoprint.timelapse.capture.pre
 .. _sec-plugins-hook-timelapse-capture-post:
 
 octoprint.timelapse.capture.post
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. py:function:: capture_post_hook(filename, success)
 

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -17,6 +17,7 @@ except ImportError:
 	import Queue as queue
 import requests
 
+import octoprint.plugin
 import octoprint.util as util
 
 from octoprint.settings import settings
@@ -344,6 +345,11 @@ class Timelapse(object):
 
 		self._fps = fps
 
+
+		self._pluginManager = octoprint.plugin.plugin_manager()
+		self._pre_capture_hooks = self._pluginManager.get_hooks("octoprint.timelapse.capture.pre")
+		self._post_capture_hooks = self._pluginManager.get_hooks("octoprint.timelapse.capture.post")
+
 		self._capture_mutex = threading.Lock()
 		self._capture_queue = queue.Queue()
 		self._capture_queue_active = True
@@ -553,6 +559,13 @@ class Timelapse(object):
 				entry["callback"](*args, **kwargs)
 
 	def _perform_capture(self, filename, onerror=None):
+		# pre-capture hook
+		for name, hook in self._pre_capture_hooks.items():
+			try:
+				hook(filename)
+			except:
+				self._logger.exception("Error while processing hook {name}.".format(**locals()))
+
 		eventManager().fire(Events.CAPTURE_START, dict(file=filename))
 		try:
 			self._logger.debug("Going to capture {} from {}".format(filename, self._snapshot_url))
@@ -568,17 +581,31 @@ class Timelapse(object):
 			self._logger.debug("Image {} captured from {}".format(filename, self._snapshot_url))
 		except Exception as e:
 			self._logger.exception("Could not capture image {} from {}".format(filename, self._snapshot_url))
+			self._capture_errors += 1
+			success = False
+		else:
+			self._capture_success += 1
+			success = True
+
+		# post-capture hook
+		for name, hook in self._post_capture_hooks.items():
+			try:
+				hook(filename, success)
+			except:
+				self._logger.exception("Error while processing hook {name}.".format(**locals()))
+
+		# handle events and onerror call
+		if success:
+			eventManager().fire(Events.CAPTURE_DONE, dict(file=filename))
+			return True
+		else:
 			if callable(onerror):
 				onerror()
 			eventManager().fire(Events.CAPTURE_FAILED, dict(file=filename,
 			                                                error=str(e),
 			                                                url=self._snapshot_url))
-			self._capture_errors += 1
 			return False
-		else:
-			eventManager().fire(Events.CAPTURE_DONE, dict(file=filename))
-			self._capture_success += 1
-			return True
+
 
 	def _copying_postroll(self):
 		with self._capture_mutex:


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Adds pre/post timelapse capture hooks. In my case it provides the functionality to create a plugin that can turn on my lighting prior to a capture and off when finished which reduces power consumption.

#### How was it tested? How can it be tested by the reviewer?
Tested by creating a dummy plugin utilizing these pre/post hooks on OctoPrint 1.3.2. Also tested using both Timed and ZChange capturing methods.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
