### PR TITLE
Software update plugin: added check_type "bitbucket_commit"

### DIFF
--- a/src/octoprint/plugins/softwareupdate/__init__.py
+++ b/src/octoprint/plugins/softwareupdate/__init__.py
@@ -113,7 +113,7 @@ class SoftwareUpdatePlugin(octoprint.plugin.BlueprintPlugin,
 								# This used to be part of the settings migration (version 2) due to a bug - it can't
 								# stay there though since it interferes with manual entries to the checks not
 								# originating from within a plugin. Hence we do that step now here.
-								if "type" not in effective_config or effective_config["type"] != "github_commit":
+								if "type" not in effective_config or effective_config["type"] not in ["github_commit", "bitbucket_commit"]:
 									deletables = ["current", "displayVersion"]
 								else:
 									deletables = []
@@ -378,7 +378,7 @@ class SoftwareUpdatePlugin(octoprint.plugin.BlueprintPlugin,
 			configured_checks = self._settings.get(["checks"], incl_defaults=False)
 			if configured_checks is not None and "octoprint" in configured_checks:
 				octoprint_check = dict(configured_checks["octoprint"])
-				if "type" not in octoprint_check or octoprint_check["type"] != "github_commit":
+				if "type" not in octoprint_check or octoprint_check["type"] not in ["github_commit", "bitbucket_commit"]:
 					deletables=["current", "displayName", "displayVersion"]
 				else:
 					deletables=[]
@@ -827,7 +827,7 @@ class SoftwareUpdatePlugin(octoprint.plugin.BlueprintPlugin,
 			self._settings.load()
 
 			# persist the new version if necessary for check type
-			if check["type"] == "github_commit":
+			if check["type"] in ["github_commit", "bitbucket_commit"]:
 				dummy_default = dict(plugins=dict())
 				dummy_default["plugins"][self._identifier] = dict(checks=dict())
 				dummy_default["plugins"][self._identifier]["checks"][target] = dict(current=None)
@@ -884,7 +884,7 @@ class SoftwareUpdatePlugin(octoprint.plugin.BlueprintPlugin,
 				release_branches += [x["branch"] for x in check["prerelease_branches"]]
 			result["released_version"] = not release_branches or BRANCH in release_branches
 
-			if check["type"] == "github_commit":
+			if check["type"] in ["github_commit", "bitbucket_commit"]:
 				result["current"] = REVISION if REVISION else "unknown"
 			else:
 				result["current"] = VERSION
@@ -938,7 +938,7 @@ class SoftwareUpdatePlugin(octoprint.plugin.BlueprintPlugin,
 				# displayVersion AND current missing or None
 				result["displayVersion"] = u"unknown"
 
-			if check["type"] in ("github_commit",):
+			if check["type"] in ["github_commit", "bitbucket_commit"]:
 				result["current"] = check.get("current", None)
 			else:
 				result["current"] = check.get("current", check.get("displayVersion", None))
@@ -974,6 +974,8 @@ class SoftwareUpdatePlugin(octoprint.plugin.BlueprintPlugin,
 			return version_checks.github_release
 		elif check_type == "github_commit":
 			return version_checks.github_commit
+		elif check_type == "bitbucket_commit":
+			return version_checks.bitbucket_commit
 		elif check_type == "git_commit":
 			return version_checks.git_commit
 		elif check_type == "commandline":

--- a/src/octoprint/plugins/softwareupdate/version_checks/__init__.py
+++ b/src/octoprint/plugins/softwareupdate/version_checks/__init__.py
@@ -5,7 +5,7 @@ __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
-from . import commandline, git_commit, github_commit, github_release, python_checker
+from . import commandline, git_commit, github_commit, github_release, bitbucket_commit, python_checker
 
 def log_github_ratelimit(logger, r):
 	ratelimit = r.headers["X-RateLimit-Limit"] if "X-RateLimit-Limit" in r.headers else "?"

--- a/src/octoprint/plugins/softwareupdate/version_checks/bitbucket_commit.py
+++ b/src/octoprint/plugins/softwareupdate/version_checks/bitbucket_commit.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
+__author__ = "Gina Häußge <osd@foosel.net>"
+__license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
+__copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
+
+import requests
+import logging
+
+from ..exceptions import ConfigurationInvalid
+
+BRANCH_HEAD_URL = "https://api.bitbucket.org/2.0/repositories/{user}/{repo}/commit/{branch}"
+
+logger = logging.getLogger("octoprint.plugins.softwareupdate.version_checks.bitbucket_commit")
+
+def _get_latest_commit(user, repo, branch):
+	result = None
+	r = requests.get(BRANCH_HEAD_URL.format(user=user, repo=repo, branch=branch))
+
+	if not r.status_code == requests.codes.ok:
+		return None
+
+	reference = r.json()
+	if not "hash" in reference:
+		return None
+
+	return reference["hash"]
+
+
+def get_latest(target, check):
+	if "user" not in check or "repo" not in check:
+		raise ConfigurationInvalid("Update configuration for %s of type bitbucket_commit needs all of user and repo" % target)
+
+	branch = "master"
+	if "branch" in check:
+		branch = check["branch"]
+
+	current = None
+	if "current" in check:
+		current = check["current"]
+
+	remote_commit = _get_latest_commit(check["user"], check["repo"], branch)
+
+	information = dict(
+		local=dict(name="Commit {commit}".format(commit=current if current is not None else "unknown"), value=current),
+		remote=dict(name="Commit {commit}".format(commit=remote_commit if remote_commit is not None else "unknown"), value=remote_commit)
+	)
+	is_current = (current is not None and current == remote_commit) or remote_commit is None
+
+	logger.debug("Target: %s, local: %s, remote: %s" % (target, current, remote_commit))
+
+	return information, is_current
+


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Adds a new version_check to software update plugin called "bitbucket_commit". It is the same as github_commit but for Bitbucket. With this you're now able to define "bitbucket_commit" as your check type so that software update can find the lastest version of your plugin if it's hosted publicly on Bitbucket. 

#### How was it tested? How can it be tested by the reviewer?
I used this check config:
```
            "check": {
                "branch": "master",
                "current": "55e4f533e29b52c7efa2cb49763608a0aa3674a2",
                "displayName": "iobeam (DEV)",
                "displayVersion": "0.2.1",
                "pip": "https://bitbucket.org/mrbeam/iobeam/get/{target_version}.zip",
                "pip_command": "sudo /usr/local/bin/pip",
                "repo": "iobeam",
                "type": "bitbucket_commit",
                "user": "mrbeam"
```
octoprint.log:
```
2017-05-02 09:38:59,927 - octoprint.plugins.softwareupdate.version_checks.bitbucket_commit - DEBUG - Target: iobeam, local: None, remote: 55e4f533e29b52c7efa2cb49763608a0aa3674a2
...
2017-05-02 12:24:32,052 - octoprint.plugins.softwareupdate - INFO - Starting update of iobeam to 55e4f533e29b52c7efa2cb49763608a0aa3674a2...
2017-05-02 12:24:41,146 - octoprint.plugins.softwareupdate - INFO - Update of iobeam to 55e4f533e29b52c7efa2cb49763608a0aa3674a2 successful!
```

After the update process OctoPrint showed the correct/new version of the updated component and the commit hash was saved correctly in config.yaml

Notice: The updated component (iobeam) is not an OctoPrint Plugin, it is some random software we use on Mr Beam II

#### Any background context you want to provide?
More or less I cloned github_commit file in version_checks

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
about Bitbucket API:

GET https://api.bitbucket.org/2.0/repositories/mrbeam/iobeam/commit/master
returns this:
```
{
    "hash": "55e4f533e29b52c7efa2cb49763608a0aa3674a2",
    "repository": {
        "links": {
            "self": {
                "href": "https://api.bitbucket.org/2.0/repositories/mrbeam/iobeam"
            },
            "html": {
                "href": "https://bitbucket.org/mrbeam/iobeam"
            },
            "avatar": {
                "href": "https://bitbucket.org/mrbeam/iobeam/avatar/32/"
            }
        },
        "type": "repository",
        "name": "iobeam",
        "full_name": "mrbeam/iobeam",
        "uuid": "{efe4a865-f57d-4ab5-be71-3e0180c317de}"
    },
    "links": {
        "self": {
            "href": "https://api.bitbucket.org/2.0/repositories/mrbeam/iobeam/commit/55e4f533e29b52c7efa2cb49763608a0aa3674a2"
        },
        "comments": {
            "href": "https://api.bitbucket.org/2.0/repositories/mrbeam/iobeam/commit/55e4f533e29b52c7efa2cb49763608a0aa3674a2/comments"
        },
        "patch": {
            "href": "https://api.bitbucket.org/2.0/repositories/mrbeam/iobeam/patch/55e4f533e29b52c7efa2cb49763608a0aa3674a2"
        },
        "html": {
            "href": "https://bitbucket.org/mrbeam/iobeam/commits/55e4f533e29b52c7efa2cb49763608a0aa3674a2"
        },
        "diff": {
            "href": "https://api.bitbucket.org/2.0/repositories/mrbeam/iobeam/diff/55e4f533e29b52c7efa2cb49763608a0aa3674a2"
        },
        "approve": {
            "href": "https://api.bitbucket.org/2.0/repositories/mrbeam/iobeam/commit/55e4f533e29b52c7efa2cb49763608a0aa3674a2/approve"
        },
        "statuses": {
            "href": "https://api.bitbucket.org/2.0/repositories/mrbeam/iobeam/commit/55e4f533e29b52c7efa2cb49763608a0aa3674a2/statuses"
        }
    },
    "author": {
        "raw": "Andy Werner <andy@mr-beam.org>",
        "user": {
            "username": "Gallore",
            "display_name": "Andy Werner",
            "type": "user",
            "uuid": "{ec9c41d3-88e1-43aa-88fd-60a29c3ac45e}",
            "links": {
                "self": {
                    "href": "https://api.bitbucket.org/2.0/users/Gallore"
                },
                "html": {
                    "href": "https://bitbucket.org/Gallore/"
                },
                "avatar": {
                    "href": "https://bitbucket.org/account/Gallore/avatar/32/"
                }
            }
        }
    },
    "participants": [

    ],
    "parents": [
        {
            "hash": "6a3d925ecd8e95b1dc4994e62433ab73a1e91d0e",
            "type": "commit",
            "links": {
                "self": {
                    "href": "https://api.bitbucket.org/2.0/repositories/mrbeam/iobeam/commit/6a3d925ecd8e95b1dc4994e62433ab73a1e91d0e"
                },
                "html": {
                    "href": "https://bitbucket.org/mrbeam/iobeam/commits/6a3d925ecd8e95b1dc4994e62433ab73a1e91d0e"
                }
            }
        }
    ],
    "date": "2017-04-27T17:57:03+00:00",
    "message": "Moved ping logic into iobeam.py, added sleep time\n",
    "type": "commit"
}
```