### PR TITLE
Add "stl_transformation_matrix" to slicing profile

### DIFF
--- a/src/octoprint/plugins/cura/__init__.py
+++ b/src/octoprint/plugins/cura/__init__.py
@@ -286,7 +286,7 @@ class CuraPlugin(octoprint.plugin.SlicerPlugin,
 				# The extruder count is needed to decide which start/end gcode will be used from the Cura profile.
 				# Stock Cura implementation counts the number of objects in the scene for this (and also takes a look
 				# at the support usage, like the engine conversion here does). We only ever have one object.
-				engine_settings = self._convert_to_engine(profile_path, printer_profile,
+				engine_settings, matrix = self._convert_to_engine(profile_path, printer_profile,
 				                                          pos_x=pos_x, pos_y=pos_y,
 				                                          used_extruders=1)
 
@@ -296,6 +296,8 @@ class CuraPlugin(octoprint.plugin.SlicerPlugin,
 				# Add the settings (sorted alphabetically) to the command
 				for k, v in sorted(engine_settings.items(), key=lambda s: s[0]):
 					args += ["-s", "%s=%s" % (k, str(v))]
+				if matrix:
+					args += ["-m", ','.join([str(item) for row in matrix for item in row])]
 				args += ["-o", machinecode_path, model_path]
 
 				self._logger.info(u"Running {!r} in {}".format(u" ".join(map(lambda x: to_unicode(x, errors="replace"),
@@ -469,7 +471,7 @@ class CuraPlugin(octoprint.plugin.SlicerPlugin,
 
 	def _convert_to_engine(self, profile_path, printer_profile, pos_x=None, pos_y=None, used_extruders=1):
 		profile = Profile(self._load_profile(profile_path), printer_profile, pos_x, pos_y)
-		return profile.convert_to_engine(used_extruders=used_extruders)
+		return profile.convert_to_engine(used_extruders=used_extruders), profile.get("stl_transformation_matrix")
 
 def _sanitize_name(name):
 	if name is None:

--- a/src/octoprint/plugins/cura/profile.py
+++ b/src/octoprint/plugins/cura/profile.py
@@ -346,7 +346,11 @@ G90                         ;absolute positioning
 """,
     postSwitchExtruder_gcode=""";Switch between the current extruder and the next extruder, when printing with multiple extruders.
 ;This code is added after the T(n)
-"""
+""",
+
+	# stl transformation
+    # 3x3 matrix: None is equivalent to [[1,0,0],[0,1,0],[0,0,1]]
+	stl_transformation_matrix=None
 )
 
 


### PR DESCRIPTION
CuraEngine has functionality to allow a 3x3 matrix transform to be applied to input stl's to achieve scaling and rotation.  It may be helpful to be able to set an intended transform in either the slicing profile or in the overrides. For example, if you're slicing for an interesting printer kinematics or to accommodate a simple UI to allow scale or rotation, but perform the operation as part of slicing rather than re-uploading a transformed stl.

Currently the matrix transform is only available via the CuraEngine "-m" command line setting and not as a "-s" setting.  In addition, CuraEngine changed it in the new cura to be expressed as an array of arrays instead of a flat list of numbers like 15.04.  So this PR proposes an abstraction that stores the matrix as a list of list in the profile and flattens it for the old cura command line.