### PR TITLE
Fix typos in strings and comments

### DIFF
--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -237,7 +237,7 @@ UpdatedFiles
 
        .. deprecated:: 1.2.0
 
-          The ``gcode`` modification type has been superceeded by ``printables``. It is currently still available for
+          The ``gcode`` modification type has been superseded by ``printables``. It is currently still available for
           reasons of backwards compatibility and will also be sent on modification of ``printables``. It will however
           be removed with 1.4.0.
 

--- a/docs/jsclientlib/base.rst
+++ b/docs/jsclientlib/base.rst
@@ -119,7 +119,7 @@
    :param string method: The HTTP method to use for the request (optional)
    :param string url: The URL to perform the request against (optional)
    :param object data: The data to send in the request body (optional)
-   :param object opts: Additonal options to use for the request (optional)
+   :param object opts: Additional options to use for the request (optional)
    :returns Promise: A `jQuery Promise <http://api.jquery.com/Types/#Promise>`_ for the request's response
 
 .. js:function:: OctoPrintClient.get(url, opts)

--- a/docs/jsclientlib/util.rst
+++ b/docs/jsclientlib/util.rst
@@ -21,7 +21,7 @@
 
 .. js:function:: OctoPrintClient.util.testPath(path, additional, opts)
 
-   Test the provided ``path`` for existance. More test criteria supported by the :ref:`path test command <sec-api-util-test-path>`
+   Test the provided ``path`` for existence. More test criteria supported by the :ref:`path test command <sec-api-util-test-path>`
    can be provided via the ``additional`` object.
 
    **Example 1**

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -958,7 +958,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 			})
 			callback.on_printer_send_initial_data(data)
 		except:
-			self._logger.exception("Error while trying to send inital state update")
+			self._logger.exception("Error while trying to send initial state update")
 
 	def _getStateFlags(self):
 		return {

--- a/src/octoprint/static/js/app/main.js
+++ b/src/octoprint/static/js/app/main.js
@@ -125,7 +125,7 @@ $(function() {
             return exports;
         })();
 
-        log.debug("Browser enviroment:", OctoPrint.coreui.browser);
+        log.debug("Browser environment:", OctoPrint.coreui.browser);
 
         //~~ AJAX setup
 
@@ -180,7 +180,7 @@ $(function() {
             gettext("Printing"),
             gettext("Paused"),
             gettext("Closed"),
-            gettext("Transfering file to SD")
+            gettext("Transferring file to SD")
         ];
 
         //~~ Initialize PNotify
@@ -340,7 +340,7 @@ $(function() {
                     continue;
                 }
 
-                // we could resolve the depdendencies and the view model is not defined yet => add it, it's now fully processed
+                // we could resolve the dependencies and the view model is not defined yet => add it, it's now fully processed
                 var viewModelBindTargets = viewModel.elements;
 
                 if (additionalBindings.hasOwnProperty(viewModel.name)) {
@@ -672,7 +672,7 @@ $(function() {
          * onServerConnect below takes care of the passive login. Only once that's completed it tells
          * our DataUpdater that it's ok to trigger any callbacks in view models. On the initial
          * server connect (during first initialization) we also trigger the settings fetch and
-         * binding proceedure once that's done, but only then.
+         * binding procedure once that's done, but only then.
          *
          * Or, as a fancy diagram: https://gist.githubusercontent.com/foosel/0cdc3a03cf5311804271f12e87293c0c/raw/abc84fdc3b13030d70961539d9c132ae39c32085/octoprint_web_startup.txt
          */
@@ -686,7 +686,7 @@ $(function() {
                     // passive login request.
                     //
                     // This is to ensure that we have no concurrent requests triggered by socket events
-                    // overriding each other's session during app intialization
+                    // overriding each other's session during app initialization
                     dataUpdater.initialized();
                 });
         };

--- a/src/octoprint/static/js/app/viewmodels/slicing.js
+++ b/src/octoprint/static/js/app/viewmodels/slicing.js
@@ -15,7 +15,7 @@ $(function() {
         self.defaultProfile = undefined;
 
         self.destinationFilename = ko.observable();
-        self.gcodeFilename = self.destinationFilename; // TODO: for backwards compatiblity, mark deprecated ASAP
+        self.gcodeFilename = self.destinationFilename; // TODO: for backwards compatibility, mark deprecated ASAP
 
         self.title = ko.observable();
         self.slicer = ko.observable();

--- a/src/octoprint/static/js/app/viewmodels/system.js
+++ b/src/octoprint/static/js/app/viewmodels/system.js
@@ -51,7 +51,7 @@ $(function() {
                         if (commandSpec.async) {
                             text = gettext("The command \"%(command)s\" executed successfully");
                         } else {
-                            text = gettext("The command \"%(command)s\" was triggered asychronously");
+                            text = gettext("The command \"%(command)s\" was triggered asynchronously");
                         }
 
                         new PNotify({

--- a/src/octoprint/templates/tabs/terminal.jinja2
+++ b/src/octoprint/templates/tabs/terminal.jinja2
@@ -27,7 +27,7 @@
     <div class="hide">
         <p class="row-fluid">
             <button class="btn btn-primary btn-block" type="button" data-bind="click: fakeAck, enable: isOperational() && loginState.isUser()">{{ _("Fake Acknowledgement") }}</button>
-            <small class="muted">{{ _("If acknowledgements (\"ok\"s) sent by the firmware get lost due to issues with the serial communication to your printer, OctoPrint's communication with it can become stuck. If that happens, this can help. Please be advised that such occurences hint at general communication issues with your printer which will probably negatively influence your printing results and which you should therefore try to resolve!") }}</small>
+            <small class="muted">{{ _("If acknowledgements (\"ok\"s) sent by the firmware get lost due to issues with the serial communication to your printer, OctoPrint's communication with it can become stuck. If that happens, this can help. Please be advised that such occurrences hint at general communication issues with your printer which will probably negatively influence your printing results and which you should therefore try to resolve!") }}</small>
         </p>
         <p class="row-fluid">
             <button class="btn btn-danger span6" type="button" data-bind="toggle: forceFancyFunctionality">{{ _('Force fancy functionality') }}</button>

--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 """
-This module bundles commonly used utility methods or helper classes that are used in multiple places withing
+This module bundles commonly used utility methods or helper classes that are used in multiple places within
 OctoPrint's source code.
 """
 from __future__ import absolute_import, division, print_function

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -578,7 +578,7 @@ class MachineCom(object):
 		if state == self.STATE_CLOSED_WITH_ERROR:
 			return "Offline: %s" % (self.getErrorString())
 		if state == self.STATE_TRANSFERING_FILE:
-			return "Transfering file to SD"
+			return "Transferring file to SD"
 		return "Unknown State (%d)" % (self._state)
 
 	def getErrorString(self):
@@ -1953,7 +1953,7 @@ class MachineCom(object):
 				#Also skip errors with the SD card
 				pass
 			elif 'unknown command' in lower_line:
-				#Ignore unkown command errors, it could be a typo or some missing feature
+				#Ignore unknown command errors, it could be a typo or some missing feature
 				pass
 			elif not self.isError():
 				error_text = line[6:] if lower_line.startswith("error:") else line[2:]

--- a/src/octoprint_client/__init__.py
+++ b/src/octoprint_client/__init__.py
@@ -164,7 +164,7 @@ class SocketClient(object):
 		If no timeout is provided, the method will block until the connection could
 		be re-established.
 
-		If disconnect is set to ``True`` will disconnect the socket explictly
+		If disconnect is set to ``True`` will disconnect the socket explicitly
 		first if it is currently connected.
 
 		Arguments:


### PR DESCRIPTION
Those typos were found with codespell which is available from
https://github.com/lucasdemarchi/codespell.git

Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase your PR if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

Feel free to delete all this help text, then describe
your PR further. You may use the template provided below to do that.
The more details the better!

----

#### What does this PR do and why is it necessary?

This PR fixes some misstypings in user-visible messages, in strings that go to log files and in comments. 

#### How was it tested? How can it be tested by the reviewer?

Tested executing the unit tests and running the server.
Visual inspection of the colored diff here in github shows that only single words were changed.

#### Any background context you want to provide?

While these are trivial mistypings, having them fixed means that searching through the source will not miss these words and future runs of [codespell](https://github.com/lucasdemarchi/codespell.git) are more likely to show if anything has changed

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

I am submitting only changes to strings excluding vendor source files (eg. jQuery) and I did not change the following lines because "managable" is an object property (just let me know if you think it makes sense to replace all these occurrences with the word "manageable"):

```
src/octoprint/plugins/pluginmanager/__init__.py:463: managable  ==> manageable, manageably
src/octoprint/plugins/pluginmanager/__init__.py:464: managable  ==> manageable, manageably
src/octoprint/plugins/pluginmanager/__init__.py:963: managable  ==> manageable, manageably
src/octoprint/plugins/pluginmanager/__init__.py:963: managable  ==> manageable, manageably
src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2:50: managable  ==> manageable, manageably
src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js:231: managable  ==> manageable, manageably
src/octoprint/plugin/core.py:145: managable  ==> manageable, manageably
src/octoprint/plugin/core.py:589: managable  ==> manageable, manageably
src/octoprint/plugin/core.py:651: managable  ==> manageable, manageably
```
