### PR TITLE
Fix some rst warnings

### DIFF
--- a/docs/bundledplugins/cura.rst
+++ b/docs/bundledplugins/cura.rst
@@ -45,7 +45,7 @@ Installing CuraEngine
 
 You'll need a build of ``legacy`` branch of `CuraEngine <http://github.com/Ultimaker/CuraEngine>`_
 in order to be able to use the Cura OctoPrint plugin. You can find the ``legacy`` branch
-`here <https://github.com/ultimaker/curaengine/tree/legacy>`_.
+`here <https://github.com/ultimaker/curaengine/tree/legacy>`__.
 
 If you previously used the `old variant of the Cura integration <https://github.com/foosel/OctoPrint/wiki/Cura-Integration>`_,
 you probably still have a fully functional binary lying around in the
@@ -60,7 +60,7 @@ Compiling for Raspbian
 .. note::
 
    A binary of CuraEngine 15.04.06 precompiled on Raspbian Jessie Lite 2016-03-18 is available
-   `here <http://bit.ly/octopi_cura_engine_150406>`_. Don't forget to make it
+   `here <http://bit.ly/octopi_cura_engine_150406>`__. Don't forget to make it
    executable after copying it to your preferred destination on your Pi
    (suggestion: ``/usr/local/bin``) with ``chmod +x cura_engine``. Use at your
    own risk.

--- a/docs/plugins/hooks.rst
+++ b/docs/plugins/hooks.rst
@@ -79,7 +79,7 @@ property instead, manually instantiate your implementation instance and then add
 .. onlineinclude:: https://raw.githubusercontent.com/OctoPrint/Plugin-Examples/master/custom_action_command.py
    :linenos:
    :tab-width: 4
-   :caption: `custom_action_command.py <https://github.com/OctoPrint/Plugin-Examples/blob/master/custom_action_command.py>`_
+   :caption: `custom_action_command.py <https://github.com/OctoPrint/Plugin-Examples/blob/master/custom_action_command.py>`__
    :name: sec-plugin-concepts-hooks-example
 
 .. _sec-plugins-hooks-ordering:
@@ -370,7 +370,7 @@ octoprint.comm.protocol.action
    .. onlineinclude:: https://raw.githubusercontent.com/OctoPrint/Plugin-Examples/master/custom_action_command.py
       :linenos:
       :tab-width: 4
-      :caption: `custom_action_command.py <https://github.com/OctoPrint/Plugin-Examples/blob/master/custom_action_command.py>`_
+      :caption: `custom_action_command.py <https://github.com/OctoPrint/Plugin-Examples/blob/master/custom_action_command.py>`__
 
    :param object comm_instance: The :class:`~octoprint.util.comm.MachineCom` instance which triggered the hook.
    :param str line: The complete line as received from the printer, format ``// action:<command>``


### PR DESCRIPTION
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase your PR if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

Feel free to delete all this help text, then describe
your PR further. You may use the template provided below to do that.
The more details the better!

----

#### What does this PR do and why is it necessary?

This fixes two warnings, one that results in an user-visible change, the source of Listing 15 isn't visible in the locally built docs and it's caption shows the warning in the online docs at http://docs.octoprint.org/en/master/plugins/hooks.html#octoprint-comm-protocol-action

#### How was it tested? How can it be tested by the reviewer?

Comparing the HTML output.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

*Before this fix*
![octoprint comm protocol action-before](https://user-images.githubusercontent.com/1055635/28757212-ebdadece-757d-11e7-992f-ef162294eb1f.png)

*After this fix*
![octoprint comm protocol action-after](https://user-images.githubusercontent.com/1055635/28757214-f7b13e28-757d-11e7-9c2c-c7d2c7219f01.png)

#### Further notes
