### PR TITLE
added decorator for calls only available on the first run.

### DIFF
--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -1110,6 +1110,23 @@ def restricted_access(func):
 	return decorated_view
 
 
+def firstrun_only_access(func):
+	"""
+	If you decorate a view with this, it will ensure that first setup has _not_ been
+	done for OctoPrint's Access Control. Otherwise it 
+	will cause a HTTP 403 status code to be returned by the decorated resource.
+	"""
+	@functools.wraps(func)
+	def decorated_view(*args, **kwargs):
+		# if OctoPrint has been set up yet, abort
+		if settings().getBoolean(["server", "firstRun"]) and (octoprint.server.userManager is None or not octoprint.server.userManager.hasBeenCustomized()):
+			return func(*args, **kwargs)
+		else:
+			return flask.make_response("OctoPrint is already setup, this resource is not longer available.", 403)
+
+	return decorated_view
+
+
 class AppSessionManager(object):
 
 	VALIDITY_UNVERIFIED = 1 * 60 # 1 minute


### PR DESCRIPTION
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint) - useful for plugin developers
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket - not a large change
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else) - maintenance branch
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase your PR if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests - tested, but no unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

Feel free to delete all this help text, then describe
your PR further. You may use the template provided below to do that.
The more details the better!

----

#### What does this PR do and why is it necessary?
enables plugins to provide blueprint urls only available on the first run

#### How was it tested? How can it be tested by the reviewer?
annotated my blueprint with @firstrun_only_access and it was only callable when no config.yaml and users.yaml were present.

#### Any background context you want to provide?
we need that to do an initial calibration of our camera assistance, but before the user setup has been done. 

#### What are the relevant tickets if any?
-

#### Screenshots (if appropriate)
-

#### Further notes
-