### PR TITLE
Maintenance Issue #2077

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -81,6 +81,7 @@ date of first contribution):
   * [Shawn Bruce](https://github.com/kantlivelong)
   * [Claudiu Ceia] (https://github.com/ClaudiuCeia)
   * [Goswin von Brederlow](https://github.com/mrvn)
+  * [Luke McKechnie](https://github.com/galamdring)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and


### PR DESCRIPTION
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase your PR if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests 
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

Feel free to delete all this help text, then describe
your PR further. You may use the template provided below to do that.
The more details the better!

----

#### What does this PR do and why is it necessary?
Corrects Issue #2077 caused by the temperature graph only watching Tool0 when Shared Nozzle is enabled, but Comm assigned the temperature it gets to the current tool.
#### How was it tested? How can it be tested by the reviewer?
         -- Tested with Shared nozzle on, and off. Temp(actual and target) were assigned to Tool0 correctly when SharedNozzle was enabled, and only to the current tool when it was not. 
         -- I was unable to test with multiple temps coming from the firmware, but with the behavior I witnessed, I feel confident that it does not break that functionality.
#### Any background context you want to provide?

#### What are the relevant tickets if any?
Issue #2077 
#### Screenshots (if appropriate)

#### Further notes
