### PR TITLE
Add print interruption warning to auto update dialog

### DIFF
--- a/src/octoprint/plugins/softwareupdate/templates/softwareupdate.jinja2
+++ b/src/octoprint/plugins/softwareupdate/templates/softwareupdate.jinja2
@@ -19,6 +19,12 @@
             {{ _('Be sure to read through any linked release notes, especially those for OctoPrint since they might contain important information you need to know <strong>before</strong> upgrading.') }}
         </p>
         <p>
+            <h5>{{ _('This action may disrupt any ongoing print jobs.') }}</h5>
+        </p>
+        <p>
+            {{ _('Depending on your printer\'s controller and general setup, restarting OctoPrint may cause your printer to be reset.') }}
+        </p>
+        <p>
             {{ _('Are you sure you want to proceed?') }}
         </p>
     </div>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Adds a warning to the auto updater dialog about possibly resetting your printer. This typically only applies when using octoprint to *monitor* a printer that is printing off an SD card, which was initiated via the LCD panel in which case OctoPrint has no way of knowing the printer is busy and therefore won't automatically block the installation of updates.

#### How was it tested? How can it be tested by the reviewer?

Install an old version of a  plugin or octoprint, allow it to notify you of an update, observe the new dialog box warns about a possible reset 

#### Any background context you want to provide?

Fills in a missing piece of a feature request that was missed on the first PR

#### What are the relevant tickets if any?

https://github.com/foosel/OctoPrint/issues/2131

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/9030085/31528486-e07ead98-b016-11e7-8e1c-1b4278518fad.png)

#### Further notes

