### PR TITLE
Handle non-[existent/functioning] tools 

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/temperature.js
+++ b/src/octoprint/static/js/app/viewmodels/temperature.js
@@ -210,6 +210,9 @@ $(function() {
                 if (lastData.hasOwnProperty("tool" + i)) {
                     tools[i]["actual"](lastData["tool" + i].actual);
                     tools[i]["target"](lastData["tool" + i].target);
+                } else {
+                    tools[i]["actual"](0);
+                    tools[i]["target"](0);
                 }
             }
 

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -2604,7 +2604,7 @@ class MachineCom(object):
 		if not match and support_r:
 			match = regexes_parameters["floatR"].search(cmd)
 
-		if match:
+		if match and self.last_temperature.tools.get(toolNum) is not None:
 			try:
 				target = float(match.group("value"))
 				self.last_temperature.set_tool(toolNum, target=target)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
1. Resolves an issue where sending M104/M109 specifying a non-existent tool(T) will result in the actual temp being recorded as None.

2. Updates the temperature data for invalid tools so that the UI sets the target temperature back to off.

#### How was it tested? How can it be tested by the reviewer?
I've only tested this on a printer with one tool. Would be great if someone with multiple could test prior to merge.

1. In the terminal send `M104 T1 S100` to a printer with only one tool. Temperature data should no longer include the non-[existent/functioning] tool.
2. Set the temperature in the UI for a non-[existent/functioning] tool. The target temperature should revert back to off.

NOTE: Temperature may still set for T0 if there is only one tool defined in the firmware.

#### Any background context you want to provide?

#### What are the relevant tickets if any?
[PSUControl#68](https://github.com/kantlivelong/OctoPrint-PSUControl/issues/68)

#### Screenshots (if appropriate)

#### Further notes
