### PR TITLE
Isolate plugin JavaScript in anonymous functions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -84,6 +84,7 @@ date of first contribution):
   * [Goswin von Brederlow](https://github.com/mrvn)
   * [Luke McKechnie](https://github.com/galamdring)
   * [Peter Backx](https://github.com/pbackx)
+  * [Josh Major](https://github.com/astateofblank)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -454,7 +454,7 @@ class Server(object):
 		def mime_type_guesser(path):
 			from octoprint.filemanager import get_mime_type
 			return get_mime_type(path)
-	
+
 		def download_name_generator(path):
 			metadata = fileManager.get_metadata("local", path)
 			if metadata and "display" in metadata:
@@ -1235,16 +1235,18 @@ class Server(object):
 		less_plugins = list(dynamic_plugin_assets["external"]["less"])
 
 		# a couple of custom filters
-		from octoprint.server.util.webassets import LessImportRewrite, JsDelimiterBundler, SourceMapRewrite, SourceMapRemove
+		from octoprint.server.util.webassets import LessImportRewrite, JsDelimiterBundler, JsPluginDelimiterBundler, SourceMapRewrite, SourceMapRemove
 		from webassets.filter import register_filter
 
 		register_filter(LessImportRewrite)
 		register_filter(SourceMapRewrite)
 		register_filter(SourceMapRemove)
 		register_filter(JsDelimiterBundler)
+		register_filter(JsPluginDelimiterBundler)
 
 		# JS
 		js_filters = ["sourcemap_remove", "js_delimiter_bundler"]
+		js_plugin_filters = js_filters + ["js_plugin_delimiter_bundler"]
 
 		js_libs_bundle = Bundle(*js_libs, output="webassets/packed_libs.js", filters=",".join(js_filters))
 
@@ -1254,7 +1256,7 @@ class Server(object):
 		if len(js_plugins) == 0:
 			js_plugins_bundle = Bundle(*[])
 		else:
-			js_plugins_bundle = Bundle(*js_plugins, output="webassets/packed_plugins.js", filters=",".join(js_filters))
+			js_plugins_bundle = Bundle(*js_plugins, output="webassets/packed_plugins.js", filters=",".join(js_plugin_filters))
 
 		js_app_bundle = Bundle(js_plugins_bundle, js_core_bundle, output="webassets/packed_app.js", filters=",".join(js_filters))
 

--- a/src/octoprint/server/util/webassets.py
+++ b/src/octoprint/server/util/webassets.py
@@ -98,3 +98,12 @@ class JsDelimiterBundler(Filter):
 	def input(self, _in, out, **kwargs):
 		out.write(_in.read())
 		out.write("\n;\n")
+
+class JsPluginDelimiterBundler(Filter):
+	name = "js_plugin_delimiter_bundler"
+	options = {}
+
+	def input(self, _in, out, **kwargs):
+		out.write("(function () {\n    try {\n        ")
+		out.write(_in.read().replace('\n', '\n        '))
+		out.write("\n    } catch (error) {\n        console.error(error);\n    }\n})();\n")


### PR DESCRIPTION
----

#### What does this PR do and why is it necessary?

This PR wraps the plugins' Javascript in anonymous functions and try/catch blocks to isolate them from each other in regards to errors and global directives.

#### How was it tested? How can it be tested by the reviewer?

Create and enable 2 plugins - the first should contain a JavaScript file with a run time error, and the second should contain a Javascript file with a verifiable statement. The second plugin's JavaScript should still execute, and an error should be shown in the browser console for the first.

#### Any background context you want to provide?

https://github.com/malnvenshorn/OctoPrint-FilamentManager/pull/32
https://github.com/kennethjiang/OctoPrint-Anywhere/issues/28

#### What are the relevant tickets if any?

#2200 

#### Further notes

I struggled to find information on how to run the unit tests. If there are issues, please provide some guidance.
