### PR TITLE
Fix __future__ import in util

### DIFF
--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -1,11 +1,10 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 """
 This module bundles commonly used utility methods or helper classes that are used in multiple places withing
 OctoPrint's source code.
 """
-from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

It fixes a syntax issue that CPython implementations simply ignore, but makes PyPy crash.

#### How was it tested? How can it be tested by the reviewer?

Start OctoPrint with PyPy. Without this commit you'll have this error:

```
Traceback (most recent call last):
  File "./octoprint", line 11, in <module>
    load_entry_point('OctoPrint==1.3.6.dev130+g79581c39', 'console_scripts', 'octoprint')()
  File "/home/octoprint/pypyvenv/site-packages/OctoPrint-1.3.6.dev130+g79581c39-py2.7.egg/octoprint/__init__.py", line 557, in main
    from octoprint.cli import octo
  File "/home/octoprint/pypyvenv/site-packages/OctoPrint-1.3.6.dev130+g79581c39-py2.7.egg/octoprint/cli/__init__.py", line 136, in <module>
    from .dev import dev_commands
  File "/home/octoprint/pypyvenv/site-packages/OctoPrint-1.3.6.dev130+g79581c39-py2.7.egg/octoprint/cli/dev.py", line 234, in <module>
    @dev_commands.group(name="dev", cls=OctoPrintDevelCommands)
  File "/home/octoprint/pypyvenv/site-packages/click-6.2-py2.7.egg/click/core.py", line 1169, in decorator
    cmd = group(*args, **kwargs)(f)
  File "/home/octoprint/pypyvenv/site-packages/click-6.2-py2.7.egg/click/decorators.py", line 115, in decorator
    cmd = _make_command(f, name, attrs, cls)
  File "/home/octoprint/pypyvenv/site-packages/click-6.2-py2.7.egg/click/decorators.py", line 89, in _make_command
    callback=f, params=params, **attrs)
  File "/home/octoprint/pypyvenv/site-packages/OctoPrint-1.3.6.dev130+g79581c39-py2.7.egg/octoprint/cli/dev.py", line 26, in __init__
    from octoprint.util.commandline import CommandlineCaller
  File "/home/octoprint/pypyvenv/site-packages/OctoPrint-1.3.6.dev130+g79581c39-py2.7.egg/octoprint/util/__init__.py", line 8
SyntaxError: __future__ statements must appear at beginning of file
```

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

(Sorry I've had very little time to check the other PRs and issues I've been contributing to)
By the way, OctoPrint is a lot faster on PyPy. You should try it. Install python dependencies + `pypy` and `pypy-dev` for headers.