### PR TITLE
Respond with 411 Length Required when missing

### DIFF
--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -184,7 +184,7 @@ class UploadStorageFallbackHandler(tornado.web.RequestHandler):
 			if self.is_multipart():
 				if not self._bytes_left:
 					# we don't support requests without a content-length
-					raise tornado.web.HTTPError(400, log_message="No Content-Length supplied")
+					raise tornado.web.HTTPError(411, log_message="No Content-Length supplied")
 
 				# extract the multipart boundary
 				fields = self._content_type.split(";")


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Changes HTTP response code for file upload to 411 (Length Required) instead of 400 (Bad Request) when Content-Length is missing. It is very hard for the client to guess that length is required by the server when the response doesn't say anything about why it's a bad request, and it's perfectly valid to do a file upload without a Content-Length in the header. Using 411 response code tells the client _why_ it's a bad request.

#### How was it tested? How can it be tested by the reviewer?

I don't know python, and the documentation is not good enough to explain how to setup and run the unit tests. The only thing this change will possibly break is an already broken client, or a unit test that is hard-coded to expect 400 (which is essentially the same as 411 - just less informative).

#### Any background context you want to provide?

https://tools.ietf.org/html/rfc7231#section-6.5.10