### PR TITLE
Improve the checksumming speed.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -85,6 +85,7 @@ date of first contribution):
   * [Luke McKechnie](https://github.com/galamdring)
   * [Peter Backx](https://github.com/pbackx)
   * [Josh Major](https://github.com/astateofblank)
+  * ["alex-gh"](https://github.com/alex-gh)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -2472,8 +2472,8 @@ class MachineCom(object):
 	def _do_send_with_checksum(self, command, linenumber):
 		command_to_send = "N" + str(linenumber) + " " + command
 		checksum = 0
-		for c in command_to_send:
-			checksum ^= ord(c)
+		for c in bytearray(command_to_send):
+			checksum ^= c
 		command_to_send = command_to_send + "*" + str(checksum)
 		self._do_send_without_checksum(command_to_send)
 


### PR DESCRIPTION
This PR improves the checksumming speed by a factor of 1.4-3.4. It does so by avoiding the overhead of calling ord() for every single character.

It has been tested by providing the same data to the old and the new algorithm and getting the same result back.