### PR TITLE
[WIP] Setup file cursror location during file analyzis

### DIFF
--- a/src/octoprint/cli/analysis.py
+++ b/src/octoprint/cli/analysis.py
@@ -30,7 +30,7 @@ def util():
 @click.option("--progress", "progress", is_flag=True)
 @click.option("--position", "end_position", type=int, default=None)
 @click.argument("path", type=click.Path())
-def gcode_command(path, speedx, speedy, speedz, offset, maxt, throttle, throttle_lines, g90_extruder, progress):
+def gcode_command(path, speedx, speedy, speedz, offset, maxt, throttle, throttle_lines, g90_extruder, progress, end_position):
 	"""Runs a GCODE file analysis."""
 
 	import time
@@ -67,7 +67,8 @@ def gcode_command(path, speedx, speedy, speedz, offset, maxt, throttle, throttle
 					 offsets=offsets,
 					 throttle=throttle_callback,
 					 max_extruders=maxt,
-					 g90_extruder=g90_extruder)
+					 g90_extruder=g90_extruder,
+					 end_position=end_position)
 
 	click.echo("DONE:{}s".format(time.time() - start_time))
 	click.echo("RESULTS:")

--- a/src/octoprint/cli/analysis.py
+++ b/src/octoprint/cli/analysis.py
@@ -28,6 +28,7 @@ def util():
 @click.option("--max-t", "maxt", type=int, default=10)
 @click.option("--g90-extruder", "g90_extruder", is_flag=True)
 @click.option("--progress", "progress", is_flag=True)
+@click.option("--position", "end_position", type=int, default=None)
 @click.argument("path", type=click.Path())
 def gcode_command(path, speedx, speedy, speedz, offset, maxt, throttle, throttle_lines, g90_extruder, progress):
 	"""Runs a GCODE file analysis."""

--- a/src/octoprint/filemanager/analysis.py
+++ b/src/octoprint/filemanager/analysis.py
@@ -249,6 +249,7 @@ class AbstractAnalysisQueue(object):
 			                                                       "path": entry.path,
 			                                                       "origin": entry.location,
 			                                                       "type": entry.type,
+																   "position": entry.position,
 
 			                                                       # TODO deprecated, remove in 1.4.0
 			                                                       "file": entry.path})
@@ -332,6 +333,8 @@ class GcodeAnalysisQueue(AbstractAnalysisQueue):
 				command += ["--offset", str(offset[0]), str(offset[1])]
 			if g90_extruder:
 				command += ["--g90-extruder"]
+			if self._current.position is not None:
+				command += ["--position={}".format(self._current.position)]
 			command.append(self._current.absolute_path)
 
 			self._logger.info("Invoking analysis command: {}".format(" ".join(command)))
@@ -384,7 +387,7 @@ class GcodeAnalysisQueue(AbstractAnalysisQueue):
 			if analysis["extrusion_length"]:
 				result["filament"] = dict()
 				for i in range(len(analysis["extrusion_length"])):
-					result["filament"]["tool%d" % i] = {
+					result["filament"]["tools"][i] = {
 						"length": analysis["extrusion_length"][i],
 						"volume": analysis["extrusion_volume"][i]
 					}

--- a/src/octoprint/filemanager/analysis.py
+++ b/src/octoprint/filemanager/analysis.py
@@ -249,7 +249,7 @@ class AbstractAnalysisQueue(object):
 			                                                       "path": entry.path,
 			                                                       "origin": entry.location,
 			                                                       "type": entry.type,
-																   "position": entry.position,
+			                                                       "position": entry.position,
 
 			                                                       # TODO deprecated, remove in 1.4.0
 			                                                       "file": entry.path})

--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -206,19 +206,19 @@ class gcode(object):
 		            maxY=self._minMax.max.y,
 		            maxZ=self._minMax.max.z)
 
-	def load(self, filename, throttle=None, speedx=6000, speedy=6000, offsets=None, max_extruders=10, g90_extruder=False):
+	def load(self, filename, throttle=None, speedx=6000, speedy=6000, offsets=None, max_extruders=10, g90_extruder=False, end_position=None):
 		if os.path.isfile(filename):
 			self.filename = filename
 			self._fileSize = os.stat(filename).st_size
 
 			with codecs.open(filename, encoding="utf-8", errors="replace") as f:
-				self._load(f, throttle=throttle, speedx=speedx, speedy=speedy, offsets=offsets, max_extruders=max_extruders, g90_extruder=g90_extruder)
+				self._load(f, throttle=throttle, speedx=speedx, speedy=speedy, offsets=offsets, max_extruders=max_extruders, g90_extruder=g90_extruder, end_position=end_position)
 
 	def abort(self, reenqueue=True):
 		self._abort = True
 		self._reenqueue = reenqueue
 
-	def _load(self, gcodeFile, throttle=None, speedx=6000, speedy=6000, offsets=None, max_extruders=10, g90_extruder=False):
+	def _load(self, gcodeFile, throttle=None, speedx=6000, speedy=6000, offsets=None, max_extruders=10, g90_extruder=False, end_position=None):
 		lineNo = 0
 		readBytes = 0
 		pos = Vector3D(0.0, 0.0, 0.0)
@@ -248,6 +248,9 @@ class gcode(object):
 				raise AnalysisAborted(reenqueue=self._reenqueue)
 			lineNo += 1
 			readBytes += len(line.encode("utf-8"))
+
+			if (end_position is not None and lineNo >= end_position):
+				break
 
 			if isinstance(gcodeFile, (file, codecs.StreamReaderWriter)):
 				percentage = float(readBytes) / float(self._fileSize)


### PR DESCRIPTION
As a summary, please make sure you have ticked all points on this
checklist:

  * [ ] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [ ] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else)
  * [ ] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature
  * [ ] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase your PR if necessary!
  * [ ] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

----

#### What does this PR do and why is it necessary?

Analyze gcode file (filament usage etc.) regarding the end position of file cursor.
For exemple, if print is canceled, analysis should read GCODE from begining to cancel point in file, instead of the full file.
Add also multi extruder support (more than 2...)

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
