### PR TITLE
Added ResettableTimer class

### DIFF
--- a/tests/util/test_resettable_timer.py
+++ b/tests/util/test_resettable_timer.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
+__author__ = "Gina Häußge <osd@foosel.net>"
+__license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
+__copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms of the AGPLv3 License"
+
+import unittest
+import mock
+import time
+
+from octoprint.util import ResettableTimer
+
+class ResettableTimerTest(unittest.TestCase):
+
+	def setUp(self):
+		pass
+
+	def test_function(self):
+		timer_task = mock.MagicMock()
+
+		timer = ResettableTimer(10, timer_task)
+		timer.start()
+
+		# wait for it
+		timer.join()
+
+		self.assertEqual(1, timer_task.call_count)
+
+	def test_reset_callback(self):
+		timer_task = mock.MagicMock()
+		on_reset_cb = mock.MagicMock()
+
+		timer = ResettableTimer(10, timer_task, on_reset=on_reset_cb)
+		timer.start()
+
+		timer.reset()
+
+		# wait for it
+		timer.join()
+
+		self.assertEqual(1, timer_task.call_count)
+		self.assertEqual(1, on_reset_cb.call_count)
+
+	def test_canceled_callback(self):
+		timer_task = mock.MagicMock()
+		on_cancelled_cb = mock.MagicMock()
+
+		timer = ResettableTimer(10, timer_task, on_cancelled=on_cancelled_cb)
+		timer.start()
+
+		time.sleep(5)
+		
+		timer.cancel()
+
+		time.sleep(10)
+
+		self.assertEqual(0, timer_task.call_count)
+		self.assertEqual(1, on_cancelled_cb.call_count)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Adds a ResettableTimer class that can be used for things such as a resettable activity timeout. Testing shows 800% performance increase over a traditional Timer.
  
ResettableTimer Test Results:
1707017 function calls in 4.889 seconds

Regular Timer Results:
6105740 function calls in 39.211 seconds
 
#### How was it tested? How can it be tested by the reviewer?
Tested with the PSUControl plugin. Currently used as an activity timeout for sent gcode.

ResettableTimer Test: https://pastebin.com/dmLNfBdF
Regular Timer Test: https://pastebin.com/NwG7uC0r

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
While I don't see any existing uses for this in core, it was suggested that I make a PR for this so that others may use it in plugins if desired.