### PR TITLE
[WIP] Add user informations in print events

### DIFF
--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1222,10 +1222,13 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 			_, name = self._fileManager.split_path(FileDestinations.LOCAL, path)
 			origin = FileDestinations.LOCAL
 
+		from flask.ext.login import current_user
+
 		result= dict(name=name,
 		             path=path,
 		             origin=origin,
 		             size=print_job_size,
+					 event_user=current_user,
 
 		             # TODO deprecated, remove in 1.4.0
 		             file=full_path,
@@ -1233,6 +1236,8 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
 		if position is not None:
 			result["position"] = position
+
+		result["print_user"] = self._comm.getPrintUser()
 
 		return result
 

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1228,7 +1228,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 		             path=path,
 		             origin=origin,
 		             size=print_job_size,
-					 event_user=current_user,
+		             event_user=current_user,
 
 		             # TODO deprecated, remove in 1.4.0
 		             file=full_path,

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -624,6 +624,9 @@ class MachineCom(object):
 			return None
 		return self._currentFile.getFilepos()
 
+	def getPrintUser(self):
+		return self._currentPrintUser
+
 	def getPrintTime(self):
 		if self._currentFile is None or self._currentFile.getStartTime() is None:
 			return None
@@ -839,6 +842,9 @@ class MachineCom(object):
 				self._changeState(self.STATE_PRINTING)
 
 				self.resetLineNumbers()
+
+				from flask.ext.login import current_user
+				self._currentPrintUser = current_user
 
 				self._callback.on_comm_print_job_started()
 


### PR DESCRIPTION
Add user which launch print and make current event in all print events

As a summary, please make sure you have ticked all points on this
checklist:

  * [ ] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [ ] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else)
  * [ ] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature
  * [ ] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase your PR if necessary!
  * [ ] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

Feel free to delete all this help text, then describe
your PR further. You may use the template provided below to do that.
The more details the better!

----

#### What does this PR do and why is it necessary?

* Add user which launch print in all print events : "print_user"
* Add current event user on all print events (eg. canceller user) : "event_user"
These informations have no effects for retrocompatibility, and could be used for new plugins.
In my case I think use them in "history plugin" to set automatically the good user.

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#1545 
#652

#### Screenshots (if appropriate)

#### Further notes
