### PR TITLE
disable connection state change button while printing

### DIFF
--- a/src/octoprint/templates/sidebar/connection.jinja2
+++ b/src/octoprint/templates/sidebar/connection.jinja2
@@ -10,4 +10,4 @@
 <label class="checkbox">
     <input type="checkbox" id="connection_autoconnect" data-bind="checked: settings.serial_autoconnect, css: {disabled: !isErrorOrClosed()}, enable: isErrorOrClosed() && loginState.isUser()"> {{ _('Auto-connect on server startup') }}
 </label>
-<button class="btn btn-block" id="printer_connect" data-bind="click: connect, text: buttonText(), enable: loginState.isUser()">{{ _('Connect') }}</button>
+<button class="btn btn-block" id="printer_connect" data-bind="click: connect, text: buttonText(), enable: loginState.isUser() && !isPrinting() && !isPaused()">{{ _('Connect') }}</button>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Disables the connection state change button while a print is in progress

#### How was it tested? How can it be tested by the reviewer?

* Connect to a printer (virtual printer was used for testing)
* Start a print
* Note that the connect / disconnect button is now unable to be clicked while a print is in progress or paused

#### Any background context you want to provide?

Fullfills a feature request, but in a slightly different way. The feature request was to throw up a confirmation dialog, I believe simply disabling the  button is probably safer.

#### What are the relevant tickets if any?

ref: https://github.com/foosel/OctoPrint/issues/2287

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/9030085/34030456-d1c5f940-e1b8-11e7-9798-cc7fd643dfd8.png)


#### Further notes

None