### PR TITLE
BUGFIX: Check for valid queue entry before attempting to dequeue.

### DIFF
--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -470,7 +470,9 @@ class FileManager(object):
 				file_object = hook_file_object
 
 		queue_entry = self._analysis_queue_entry(destination, path)
-		self._analysis_queue.dequeue(queue_entry)
+
+		if queue_entry is not None:
+			self._analysis_queue.dequeue(queue_entry)
 
 		path_in_storage = self._storage(destination).add_file(path, file_object, links=links, printer_profile=printer_profile, allow_overwrite=allow_overwrite, display=display)
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Resolves exception when uploading a file with an unsupported extension. pNotify would show a 500 error to end-user.

#### How was it tested? How can it be tested by the reviewer?
Upload an invalid file. "More" should show useful error to end-user instead of 500.

#### Any background context you want to provide?

#### What are the relevant tickets if any?
Issue discovered in #2316

#### Screenshots (if appropriate)

#### Further notes


  