### PR TITLE
BUGFIX: Fix M105 terminal filter to include multiple tools.

### DIFF
--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -319,7 +319,7 @@ default_settings = {
 		"apps": {}
 	},
 	"terminalFilters": [
-		{ "name": "Suppress temperature messages", "regex": "(Send: (N\d+\s+)?M105)|(Recv:\s+(ok\s+)?(B|T\d*):)" },
+		{ "name": "Suppress temperature messages", "regex": "(Send: (N\d+\s+)?M105)|(Recv:\s+(ok\s+)?([B|T]\d*):)" },
 		{ "name": "Suppress SD status messages", "regex": "(Send: (N\d+\s+)?M27)|(Recv: SD printing byte)" },
 		{ "name": "Suppress wait responses", "regex": "Recv: wait"}
 	],


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Fixes bug where tools with a number are not filtered

#### How was it tested? How can it be tested by the reviewer?
Apply regex in settings and test.

#### Any background context you want to provide?
Sample M105 response that wasn't covered:
> Recv: ok T0:235.2 /235.0 B:55.3 /55.0

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
