### PR TITLE
BUGFIX: Fix autoconnect on start so that it works with the port set to AUTO (#2311)

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -608,7 +608,7 @@ class Server(object):
 				(port, baudrate) = self._settings.get(["serial", "port"]), self._settings.getInt(["serial", "baudrate"])
 				printer_profile = printerProfileManager.get_default()
 				connectionOptions = printer.__class__.get_connection_options()
-				if port in connectionOptions["ports"]:
+				if port in connectionOptions["ports"] or port == "AUTO":
 						printer.connect(port=port, baudrate=baudrate, profile=printer_profile["id"] if "id" in printer_profile else "_default")
 			except:
 				self._logger.exception("Something went wrong while attempting to automatically connect to the printer")


### PR DESCRIPTION
----

#### What does this PR do and why is it necessary?
Resolves issue where OctoPrint does not autoconnect to the printer on startup when the port is set to AUTO.

#### How was it tested? How can it be tested by the reviewer?
1. Set port to AUTO and enable autoconnect.
2. Restart OctoPrint and see if OctoPrint connected to the printer.

#### Any background context you want to provide?

#### What are the relevant tickets if any?
#2311

#### Screenshots (if appropriate)

#### Further notes
