### PR TITLE
software xon/xoff workaround

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -86,6 +86,7 @@ date of first contribution):
   * [Peter Backx](https://github.com/pbackx)
   * [Josh Major](https://github.com/astateofblank)
   * ["alex-gh"](https://github.com/alex-gh)
+  * ["Adrian Cuzman"](https://github.com/adriancuzman)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -86,7 +86,6 @@ date of first contribution):
   * [Peter Backx](https://github.com/pbackx)
   * [Josh Major](https://github.com/astateofblank)
   * ["alex-gh"](https://github.com/alex-gh)
-  * ["Adrian Cuzman"](https://github.com/adriancuzman)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -2420,7 +2420,7 @@ class MachineCom(object):
 						command_requiring_checksum = gcode is not None and gcode in self._checksum_requiring_commands
 						command_allowing_checksum = gcode is not None or self._sendChecksumWithUnknownCommands
 						checksum_enabled = not self._neverSendChecksum and ((self.isPrinting() and self._currentFile and self._currentFile.checksum) or
-						                                                    self._alwaysSendChecksum or
+						                                                    self._alwaysSendChecksum or self._use_xonxoff_workaround or
 						                                                    not self._firmware_info_received)
 
 						command_to_send = command.encode("ascii", errors="replace")


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Yes, transferring to sdcard is very slow... with Marlin firmware, but with the new SERIAL_XON_XOFF implementation the speed can be increased.

#### How was it tested? How can it be tested by the reviewer?
I used Marlin firmware with SERIAL_XON_XOFF set. The host for Octoprint used was Linux with the software flow control bug. (I have the CP2102 USB-Serial chip)

Set to true in config file in the serial section "useSoftwareFlowWorkaround". If not set, the code is not active and will wait for 'ok' after each command. Example:

serial:
  autoconnect: true
  baudrate: 500000
  port: /dev/ttyUSB0
  useSoftwareFlowWorkaround: true   

After the config file is set. Transfer a file to sdcard. Check if file on sdcard is the same with the one sent. Transfer time should be less than before :)  

#### Any background context you want to provide?
Information about the software flow control bug:  https://github.com/neundorf/CuteCom/issues/22

#### What are the relevant tickets if any?
https://github.com/foosel/OctoPrint/issues/2261

#### Further notes
- had to increase deque to 1000 lines to have lines in history when resending commands
- there are cases when resend is triggered, but it works and the file in the end is complete without missing parts
- I don't know Python, I just learned a bit Python to make this PR, any feedback to make this code correct will be appreciated :)

