### PR TITLE
API: add 'True' as a string as a boolean

### DIFF
--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -405,7 +405,7 @@ default_settings = {
 }
 """The default settings of the core application."""
 
-valid_boolean_trues = [True, "true", "yes", "y", "1"]
+valid_boolean_trues = [True, "True", "true", "yes", "y", "1"]
 """ Values that are considered to be equivalent to the boolean ``True`` value, used for type conversion in various places."""
 
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
API: add 'True' as a string as a boolean

#### How was it tested? How can it be tested by the reviewer?
Easy to test:
curl -H "X-Api-Key: x" http://octopi.local/api/printer?history=true | grep history
curl -H "X-Api-Key: x" http://octopi.local/api/printer?history=True | grep history

The second test previously failed, with this code it succeeds.

#### Any background context you want to provide?
This allows pythonic API clients to pass boolean values in:

requests.get('/api/printer', params={'history': True})

Previously this didn't work, as Octoprint doesn't see True as a boolean, it gets a sting. So it never matches True, it only matches "True".

#### What are the relevant tickets if any?
na

#### Screenshots (if appropriate)
na

#### Further notes
Hope you get feeling better, Gina.

