### PR TITLE
timelapse: add m4v and mkv as supported container formats

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -499,7 +499,7 @@ class Server(object):
 		server_routes = self._router.urls + [
 			# various downloads
 			# .mpg and .mp4 timelapses:
-			(r"/downloads/timelapse/([^/]*\.mp[g4])", util.tornado.LargeResponseHandler, joined_dict(dict(path=self._settings.getBaseFolder("timelapse")),
+			(r"/downloads/timelapse/([^/]*\.m(.*))", util.tornado.LargeResponseHandler, joined_dict(dict(path=self._settings.getBaseFolder("timelapse")),
 			                                                                                      download_handler_kwargs,
 			                                                                                      no_hidden_files_validator)),
 			(r"/downloads/files/local/(.*)", util.tornado.LargeResponseHandler, joined_dict(dict(path=self._settings.getBaseFolder("uploads"),

--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -128,7 +128,7 @@ def downloadTimelapse(filename):
 @api.route("/timelapse/<filename>", methods=["DELETE"])
 @restricted_access
 def deleteTimelapse(filename):
-	if util.is_allowed_file(filename, ["mpg", "mpeg", "mp4"]):
+	if util.is_allowed_file(filename, ["mpg", "mpeg", "mp4", "m4v", "mkv"]):
 		timelapse_folder = settings().getBaseFolder("timelapse")
 		full_path = os.path.realpath(os.path.join(timelapse_folder, filename))
 		if full_path.startswith(timelapse_folder) and os.path.exists(full_path):

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -87,7 +87,7 @@ def get_finished_timelapses():
 	files = []
 	basedir = settings().getBaseFolder("timelapse")
 	for entry in scandir(basedir):
-		if not fnmatch.fnmatch(entry.name, "*.mp[g4]"):
+		if not fnmatch.fnmatch(entry.name, "*.m*"):
 			continue
 		files.append({
 			"name": entry.name,


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR adds 'm4v' and 'mkv' to the accepted timelapse file extensions.

Not every player can handle non-mpeg2 codecs inside a .mpg. QuickTime
Player on OSX goes a step further and won't play h264-in-mp4, only
h264-in-m4v

I'm working on adding h264 support (https://github.com/koenkooi/OctoPrint/commits/h264-setting) and the above issue surfaced and was easy enough to split out and make a seperate PR for.

#### How was it tested? How can it be tested by the reviewer?

This was tested in 2 ways:
 1. 'touch timelapse/bar.m4v' using ssh. OctoPrint showed the new file and allowed to download it.
 2. Patch timelapse.py to generate m4v files. OctoPrint showed the new file and allowed to download it.

#### Any background context you want to provide?

See above, h264 support for timelapses.

#### What are the relevant tickets if any?

https://github.com/foosel/OctoPrint/issues/2373
https://github.com/foosel/OctoPrint/issues/1980

#### Screenshots (if appropriate)

<img width="606" alt="schermafbeelding 2018-01-27 om 13 11 56" src="https://user-images.githubusercontent.com/259525/35471843-add2fe80-0363-11e8-9f3d-191a92c51a31.png">
