### PR TITLE
Trust basic authentication headers for user login

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -86,6 +86,7 @@ date of first contribution):
   * [Peter Backx](https://github.com/pbackx)
   * [Josh Major](https://github.com/astateofblank)
   * ["alex-gh"](https://github.com/alex-gh)
+  * [Bernd Zeimetz](https://github.com/bzed)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -36,7 +36,7 @@ Use the following settings to enable access control:
 
      # If set to true, will automatically log on clients originating from any of the networks defined in
      # "localNetworks" as the user defined in "autologinAs". Defaults to false.
-     autologinLocal: true
+     autologinLocal: false
 
      # The name of the user to automatically log on clients originating from "localNetworks" as. Must
      # be the name of one of your configured users.
@@ -50,6 +50,17 @@ Use the following settings to enable access control:
      localNetworks:
      - 127.0.0.0/8
      - 192.168.1.0/24
+
+     # Whether to trust Basic Authentication headers. If you have setup Basic Authentication in front of
+     # OctoPrint and the user names you use there match OctoPrint accounts, by setting this to true users will
+     # be logged into OctoPrint as the user user during Basic Authentication. Your should ONLY ENABLE THIS if your
+     # OctoPrint instance is only accessible through a connection locked down through Basic Authentication!
+     trustBasicAuthentication: false
+
+     # Whether to also check the password provided through Basic Authentication if the Basic Authentication
+     # header is to be trusted. Disabling this will only match the user name in the Basic Authentication
+     # header and login the user without further checks. Use with caution.
+     checkBasicAuthenticationPassword: true
 
 .. _sec-configuration-config_yaml-api:
 

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -148,18 +148,7 @@ def load_user(id):
 	return None
 
 def load_user_from_request(request):
-	header = request.headers.get('Authorization')
-	if header:
-		header = header.replace('Basic ', '', 1)
-		try:
-			header = base64.b64decode(header)
-		except TypeError:
-			return None
-		id = header.split(':')[0]
-		user = userManager.findUser(userid=id)
-		if user:
-			return user
-	return None
+	return util.get_user_for_authorization_header(request.headers.get('Authorization'))
 
 def unauthorized_user():
 	from flask import abort

--- a/src/octoprint/server/api/__init__.py
+++ b/src/octoprint/server/api/__init__.py
@@ -19,7 +19,7 @@ import octoprint.server
 import octoprint.plugin
 from octoprint.server import admin_permission, NO_CONTENT
 from octoprint.settings import settings as s, valid_boolean_trues
-from octoprint.server.util import noCachingExceptGetResponseHandler, enforceApiKeyRequestHandler, loginFromApiKeyRequestHandler, corsRequestHandler, corsResponseHandler
+from octoprint.server.util import noCachingExceptGetResponseHandler, enforceApiKeyRequestHandler, loginFromApiKeyRequestHandler, loginFromRequest, corsRequestHandler, corsResponseHandler
 from octoprint.server.util.flask import restricted_access, get_json_command_from_request, passive_login
 
 
@@ -47,6 +47,7 @@ api.after_request(noCachingExceptGetResponseHandler)
 
 api.before_request(corsRequestHandler)
 api.before_request(enforceApiKeyRequestHandler)
+api.before_request(loginFromRequest)
 api.before_request(loginFromApiKeyRequestHandler)
 api.after_request(corsResponseHandler)
 

--- a/src/octoprint/server/api/__init__.py
+++ b/src/octoprint/server/api/__init__.py
@@ -19,7 +19,7 @@ import octoprint.server
 import octoprint.plugin
 from octoprint.server import admin_permission, NO_CONTENT
 from octoprint.settings import settings as s, valid_boolean_trues
-from octoprint.server.util import noCachingExceptGetResponseHandler, enforceApiKeyRequestHandler, loginFromApiKeyRequestHandler, loginFromRequest, corsRequestHandler, corsResponseHandler
+from octoprint.server.util import noCachingExceptGetResponseHandler, enforceApiKeyRequestHandler, loginFromApiKeyRequestHandler, loginFromAuthorizationHeaderRequestHandler, corsRequestHandler, corsResponseHandler
 from octoprint.server.util.flask import restricted_access, get_json_command_from_request, passive_login
 
 
@@ -47,7 +47,7 @@ api.after_request(noCachingExceptGetResponseHandler)
 
 api.before_request(corsRequestHandler)
 api.before_request(enforceApiKeyRequestHandler)
-api.before_request(loginFromRequest)
+api.before_request(loginFromAuthorizationHeaderRequestHandler)
 api.before_request(loginFromApiKeyRequestHandler)
 api.after_request(corsResponseHandler)
 

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -301,7 +301,8 @@ default_settings = {
 		"userfile": None,
 		"autologinLocal": False,
 		"localNetworks": ["127.0.0.0/8"],
-		"autologinAs": None
+		"autologinAs": None,
+		"trustBasicAuthentication": False
 	},
 	"slicing": {
 		"enabled": True,

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -302,7 +302,8 @@ default_settings = {
 		"autologinLocal": False,
 		"localNetworks": ["127.0.0.0/8"],
 		"autologinAs": None,
-		"trustBasicAuthentication": False
+		"trustBasicAuthentication": False,
+		"checkBasicAuthenticationPassword": True
 	},
 	"slicing": {
 		"enabled": True,


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Using basic auth together with the normal login has some issues (#2297 for example), lets trust basic auth and avoid the double login part!

#### How was it tested? How can it be tested by the reviewer?
Setup a haproxy with basic auth as documented in the wiki and add a user with the same name in Octoprint and in the haproxy config.

#### Any background context you want to provide?

Based on #2304 and https://github.com/bzed/OctoPrint/commits/basic_auth_autologin by @bzed. Supersedes #2304. Extended to also check the password against the one on file in OctoPrint (can be disabled), add documentation for the two new config parameters and also slightly refactored to remove some redundancies.

#### What are the relevant tickets if any?

#2297, #2304

#### Screenshots (if appropriate)

#### Further notes
