### PR TITLE
Display long filenames on SD card with Marlin 1.1

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -87,6 +87,7 @@ date of first contribution):
   * [Peter Backx](https://github.com/pbackx)
   * [Josh Major](https://github.com/astateofblank)
   * ["alex-gh"](https://github.com/alex-gh)
+  * ["Kelly Anderson"](https://github.com/cbxbiker61)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -582,7 +582,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 	def get_sd_files(self):
 		if self._comm is None or not self._comm.isSdReady():
 			return []
-		return map(lambda x: (x[0][1:], x[1]), self._comm.getSdFiles())
+		return map(lambda x: (x[0][1:], x[1], x[2]), self._comm.getSdFiles())
 
 	def add_sd_file(self, filename, absolutePath, on_success=None, on_failure=None):
 		if not self._comm or self._comm.isBusy() or not self._comm.isSdReady():

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -148,11 +148,11 @@ def _getFileList(origin, path=None, filter=None, recursive=False, allow_from_cac
 
 		files = []
 		if sdFileList is not None:
-			for sdFile, sdSize in sdFileList:
+			for sdFile, sdSize, sdFileLongname in sdFileList:
 				file = {
 					"type": "machinecode",
-					"name": sdFile,
-					"display": sdFile,
+					"name": sdFileLongname if sdFileLongname else sdFile,
+					"display": sdFileLongname if sdFileLongname else sdFile,
 					"path": sdFile,
 					"origin": FileDestinations.SDCARD,
 					"refs": {


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This is a basic approach to adding long filenames support with Marlin 1.1.  Lazy lookup could be implemented quite easily by looking at the sdFileLongname for None periodically until all sdFileLongname's are populated.  As far as ASCII goes I don't know why we can't just filter the M33 response.

I feel that this support is going to become more important as printers start to support support power fail recovery as well as missed steps recovery (TMC2130 Einsy board).  These new features are going to require printing from SD card.

#### How was it tested? How can it be tested by the reviewer?

It was tested with a Marlin 1.1.8 and and Einsy board.  With 25 files it is plenty fast.

#### What are the relevant tickets if any?

https://github.com/foosel/OctoPrint/issues/1600
