### PR TITLE
[Brainstorming] Support both mpeg2 and h264 for timelapse rendering

### DIFF
--- a/docs/api/settings.rst
+++ b/docs/api/settings.rst
@@ -254,6 +254,8 @@ mapped from the same fields in ``config.yaml`` unless otherwise noted:
      -
    * - ``webcam.ffmpegThreads``
      -
+   * - ``webcam.ffmpegVideoCodec``
+     -
    * - ``webcam.watermark``
      -
    * - ``webcam.flipH``

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -1194,6 +1194,9 @@ Use the following settings to configure webcam support:
      # Should be left at 1 for RPi1.
      ffmpegThreads: 1
 
+     # Videocodec to be used for encoding. Defaults to mpeg2video.
+     ffmpegVideoCodec: mpeg2video
+
      # The bitrate to use for rendering the timelapse video. This gets directly passed to ffmpeg.
      bitrate: 5000k
 

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -108,6 +108,7 @@ def getSettings():
 			"ffmpegPath": s.get(["webcam", "ffmpeg"]),
 			"bitrate": s.get(["webcam", "bitrate"]),
 			"ffmpegThreads": s.get(["webcam", "ffmpegThreads"]),
+			"ffmpegVideoCodec": s.get(["webcam", "ffmpegVideoCodec"]),
 			"watermark": s.getBoolean(["webcam", "watermark"]),
 			"flipH": s.getBoolean(["webcam", "flipH"]),
 			"flipV": s.getBoolean(["webcam", "flipV"]),
@@ -348,6 +349,8 @@ def _saveSettings(data):
 		if "ffmpegPath" in data["webcam"]: s.set(["webcam", "ffmpeg"], data["webcam"]["ffmpegPath"])
 		if "bitrate" in data["webcam"]: s.set(["webcam", "bitrate"], data["webcam"]["bitrate"])
 		if "ffmpegThreads" in data["webcam"]: s.setInt(["webcam", "ffmpegThreads"], data["webcam"]["ffmpegThreads"])
+		# Add a whitelist for vcodecs like aspect ration has?
+		if "ffmpegVideoCodec" in data["webcam"]: s.set(["webcam", "ffmpegVideoCodec"], data["webcam"]["ffmpegVideoCodec"])
 		if "watermark" in data["webcam"]: s.setBoolean(["webcam", "watermark"], data["webcam"]["watermark"])
 		if "flipH" in data["webcam"]: s.setBoolean(["webcam", "flipH"], data["webcam"]["flipH"])
 		if "flipV" in data["webcam"]: s.setBoolean(["webcam", "flipV"], data["webcam"]["flipV"])

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -208,6 +208,7 @@ default_settings = {
 		"snapshotSslValidation": True,
 		"ffmpeg": None,
 		"ffmpegThreads": 1,
+		"ffmpegVideoCodec": "mpeg2video",
 		"bitrate": "5000k",
 		"watermark": True,
 		"flipH": False,

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -100,6 +100,7 @@ $(function() {
         };
 
         self.webcam_available_ratios = ["16:9", "4:3"];
+        self.webcam_available_videocodecs = ["mpeg2video", "libx264"];
 
         var auto_locale = {language: "_default", display: gettext("Autodetect from browser"), english: undefined};
         self.locales = ko.observableArray([auto_locale].concat(_.sortBy(_.values(AVAILABLE_LOCALES), function(n) {

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -129,6 +129,7 @@ $(function() {
         self.webcam_ffmpegPath = ko.observable(undefined);
         self.webcam_bitrate = ko.observable(undefined);
         self.webcam_ffmpegThreads = ko.observable(undefined);
+        self.webcam_ffmpegVideoCodec = ko.observable(undefined);
         self.webcam_watermark = ko.observable(undefined);
         self.webcam_flipH = ko.observable(undefined);
         self.webcam_flipV = ko.observable(undefined);

--- a/src/octoprint/templates/dialogs/settings/webcam.jinja2
+++ b/src/octoprint/templates/dialogs/settings/webcam.jinja2
@@ -26,6 +26,7 @@
             {% include "snippets/settings/webcam/ffmpegThreads.jinja2" %}
             {% include "snippets/settings/webcam/webcamSnapshotTimeout.jinja2" %}
             {% include "snippets/settings/webcam/webcamSnapshotSslValidation.jinja2" %}
+            {% include "snippets/settings/webcam/ffmpegVideoCodec.jinja2" %}
         </div>
     </div>
 </form>

--- a/src/octoprint/templates/snippets/settings/webcam/ffmpegVideoCodec.jinja2
+++ b/src/octoprint/templates/snippets/settings/webcam/ffmpegVideoCodec.jinja2
@@ -1,6 +1,6 @@
 <div class="control-group" title="{{ _('Videocodec uses for encoding') }}">
     <label class="control-label" for="settings-webcam_ffmpegVideoCodec">{{ _('Videocodec') }}</label>
     <div class="controls">
-        <input class="input-mini" data-bind="value: webcam_ffmpegVIdeoCodec" id="settings-webcamFfmpegVideoCodec" type="text">
+        <select data-bind="options: webcam_available_videocodecs, value: webcam_ffmpegVideoCodec"></select>
     </div>
 </div>

--- a/src/octoprint/templates/snippets/settings/webcam/ffmpegVideoCodec.jinja2
+++ b/src/octoprint/templates/snippets/settings/webcam/ffmpegVideoCodec.jinja2
@@ -1,0 +1,6 @@
+<div class="control-group" title="{{ _('Videocodec uses for encoding') }}">
+    <label class="control-label" for="settings-webcam_ffmpegVideoCodec">{{ _('Videocodec') }}</label>
+    <div class="controls">
+        <input class="input-mini" data-bind="value: webcam_ffmpegVIdeoCodec" id="settings-webcamFfmpegVideoCodec" type="text">
+    </div>
+</div>

--- a/tests/timelapse/test_timelapse_renderjob.py
+++ b/tests/timelapse/test_timelapse_renderjob.py
@@ -14,15 +14,19 @@ from octoprint.timelapse import TimelapseRenderJob
 class TimelapseRenderJobTest(unittest.TestCase):
 
 	@data(
-		(("/path/to/ffmpeg", 25, "10000k", 1, "/path/to/input/files_%d.jpg", "/path/to/output.mpg"),
+		(("/path/to/ffmpeg", 25, "10000k", 1, "/path/to/input/files_%d.jpg", "/path/to/output.mpg", "mpeg2video"),
 		 dict(),
 		 '/path/to/ffmpeg -framerate 25 -i "/path/to/input/files_%d.jpg" -vcodec mpeg2video -threads 1 -r 25 -y -b 10000k -f vob -vf \'[in] format=yuv420p [out]\' "/path/to/output.mpg"'),
 
-		(("/path/to/ffmpeg", 25, "10000k", 1, "/path/to/input/files_%d.jpg", "/path/to/output.mpg"),
+		(("/path/to/ffmpeg", 25, "10000k", 1, "/path/to/input/files_%d.jpg", "/path/to/output.mp4", "libx264"),
+		 dict(),
+		 '/path/to/ffmpeg -framerate 25 -i "/path/to/input/files_%d.jpg" -vcodec libx264 -threads 1 -r 25 -y -b 10000k -f mp4 -vf \'[in] format=yuv420p [out]\' "/path/to/output.mp4"'),
+
+		(("/path/to/ffmpeg", 25, "10000k", 1, "/path/to/input/files_%d.jpg", "/path/to/output.mpg", "mpeg2video"),
 		 dict(hflip=True),
 		 '/path/to/ffmpeg -framerate 25 -i "/path/to/input/files_%d.jpg" -vcodec mpeg2video -threads 1 -r 25 -y -b 10000k -f vob -vf \'[in] format=yuv420p,hflip [out]\' "/path/to/output.mpg"'),
 
-		(("/path/to/ffmpeg", 25, "20000k", 4, "/path/to/input/files_%d.jpg", "/path/to/output.mpg"),
+		(("/path/to/ffmpeg", 25, "20000k", 4, "/path/to/input/files_%d.jpg", "/path/to/output.mpg", "mpeg2video"),
 		 dict(rotate=True, watermark="/path/to/watermark.png"),
 		 '/path/to/ffmpeg -framerate 25 -i "/path/to/input/files_%d.jpg" -vcodec mpeg2video -threads 4 -r 25 -y -b 20000k -f vob -vf \'[in] format=yuv420p,transpose=2 [postprocessed]; movie=/path/to/watermark.png [wm]; [postprocessed][wm] overlay=10:main_h-overlay_h-10 [out]\' "/path/to/output.mpg"')
 	)

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -4606,6 +4606,14 @@ msgstr ""
 msgid "FFMPEG threads"
 msgstr ""
 
+#: src/octoprint/templates/snippets/settings/webcam/ffmpegVideoCodec.jinja2:1
+msgid "Videocodec uses for encoding"
+msgstr ""
+
+#: src/octoprint/templates/snippets/settings/webcam/ffmpegVideoCodec.jinja2:2
+msgid "Videocodec"
+msgstr ""
+
 #: src/octoprint/templates/snippets/settings/webcam/watermark.jinja2:4
 msgid "Enable OctoPrint watermark in timelapse movies"
 msgstr ""


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR adds a setting to use h264 as videocodec for timelapse rendering. This should give a quality boost at the same bitrate setting or allow to drop the bitrate while keeping the same quality.

I tagged it as 'RFC' because there are at least these issues still left:
- [x] ~~Spurious whitespace changes~~
- [x] ~~Missing translation strings~~
- [x] ~~Commit ordering, settings are in before the code~~
- [x] ~~Fix and extend related unit tests~~

Before I spend more time on this, is this the way to go, or should any extra changes to timelapse by done in an octopi style external script or as a module?

#### How was it tested? How can it be tested by the reviewer?

Tested by setting _Settings → Webcam & Timelapse → Timelapse Recordings → Advanced settings → Videocodec_ to 'libx264' and starting a print.
See screenshot section for details on the resulting timelapse.

#### Any background context you want to provide?

See above, h264 support for timelapses.

#### What are the relevant tickets if any?

https://github.com/foosel/OctoPrint/issues/2388
https://github.com/foosel/OctoPrint/issues/2373
https://github.com/foosel/OctoPrint/issues/1980

#### Screenshots (if appropriate)

<img width="983" alt="schermafbeelding 2018-02-08 om 15 54 53" src="https://user-images.githubusercontent.com/259525/35979360-76c8e0e2-0ce8-11e8-91c6-3f82dbb832a4.png">
<img width="616" alt="schermafbeelding 2018-02-08 om 15 58 17" src="https://user-images.githubusercontent.com/259525/35979546-e696bd90-0ce8-11e8-8264-c5b9d3723399.png">

