### PR TITLE
piptestballoon: fix typo in comment: intenional -> intentional

### DIFF
--- a/src/octoprint/util/piptestballoon/setup.py
+++ b/src/octoprint/util/piptestballoon/setup.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 """
-This "python package" doesn't actually install. This is intenional. It is merely
+This "python package" doesn't actually install. This is intentional. It is merely
 used to figure out some information about the environment a specific pip call
 is running under (installation dir, whether it belongs to a virtual environment,
 whether the install location is writable by the current user), and for that it


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

It fixes a typo in a comment.

#### How was it tested? How can it be tested by the reviewer?

I typed 'intentional' into google and it didn't correct me :)

#### Any background context you want to provide?

I was trying to debug why pip isn't working on my distro and noticed the typo.

#### What are the relevant tickets if any?

None

#### Screenshots (if appropriate)

None

#### Further notes

None