### PR TITLE
Added a new "customControls_controlTemplate_command"

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -88,6 +88,7 @@ date of first contribution):
   * [Josh Major](https://github.com/astateofblank)
   * ["alex-gh"](https://github.com/alex-gh)
   * [Bernd Zeimetz](https://github.com/bzed)
+  * [electr0sheep](https://github.com/electr0sheep)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/templates/tabs/control.jinja2
+++ b/src/octoprint/templates/tabs/control.jinja2
@@ -154,7 +154,8 @@
 <script type="text/html" id="customControls_controlTemplate">
     <form class="form-inline custom_control">
         <!-- ko template: { name: 'customControls_controlTemplate_input', data: $data, if: $data.hasOwnProperty('input') } --><!-- /ko -->
-        <!-- ko template: { name: 'customControls_controlTemplate_command', data: $data, if: $data.hasOwnProperty('command') || $data.hasOwnProperty('commands') || $data.hasOwnProperty('script') || $data.hasOwnProperty('javascript') } --><!-- /ko -->
+        <!-- ko template: { name: 'customControls_controlTemplate_command', data: $data, if: !$data.hasOwnProperty('customClass') && ($data.hasOwnProperty('command') || $data.hasOwnProperty('commands') || $data.hasOwnProperty('script') || $data.hasOwnProperty('javascript')) } --><!-- /ko -->
+        <!-- ko template: { name: 'customControls_controlTemplate_command_styled', data: $data, if: $data.hasOwnProperty('customClass') && ($data.hasOwnProperty('command') || $data.hasOwnProperty('commands') || $data.hasOwnProperty('script') || $data.hasOwnProperty('javascript')) } --><!-- /ko -->
         <!-- ko template: { name: 'customControls_controlTemplate_output', data: $data, if: $data.hasOwnProperty('output') } --><!-- /ko -->
     </form>
 </script>
@@ -174,5 +175,8 @@
 </script>
 <script type="text/html" id="customControls_controlTemplate_command">
     <button class="btn" data-bind="text: name, enable: $root.isCustomEnabled($data), click: function() { $root.clickCustom($data) }"></button>
+</script>
+<script type="text/html" id="customControls_controlTemplate_command_customClass">
+    <button data-bind="text: name, attr: { 'class': customClass }, enable: $root.isCustomEnabled($data), click: function() { $root.clickCustom($data) }"></button>
 </script>
 <!-- End of templates for custom controls -->

--- a/src/octoprint/templates/tabs/control.jinja2
+++ b/src/octoprint/templates/tabs/control.jinja2
@@ -155,7 +155,7 @@
     <form class="form-inline custom_control">
         <!-- ko template: { name: 'customControls_controlTemplate_input', data: $data, if: $data.hasOwnProperty('input') } --><!-- /ko -->
         <!-- ko template: { name: 'customControls_controlTemplate_command', data: $data, if: !$data.hasOwnProperty('customClass') && ($data.hasOwnProperty('command') || $data.hasOwnProperty('commands') || $data.hasOwnProperty('script') || $data.hasOwnProperty('javascript')) } --><!-- /ko -->
-        <!-- ko template: { name: 'customControls_controlTemplate_command_styled', data: $data, if: $data.hasOwnProperty('customClass') && ($data.hasOwnProperty('command') || $data.hasOwnProperty('commands') || $data.hasOwnProperty('script') || $data.hasOwnProperty('javascript')) } --><!-- /ko -->
+        <!-- ko template: { name: 'customControls_controlTemplate_command_customClass', data: $data, if: $data.hasOwnProperty('customClass') && ($data.hasOwnProperty('command') || $data.hasOwnProperty('commands') || $data.hasOwnProperty('script') || $data.hasOwnProperty('javascript')) } --><!-- /ko -->
         <!-- ko template: { name: 'customControls_controlTemplate_output', data: $data, if: $data.hasOwnProperty('output') } --><!-- /ko -->
     </form>
 </script>


### PR DESCRIPTION
  * [?] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase your PR if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

----

#### What does this PR do and why is it necessary?
This PR adds the ability to specify custom button classes (btn-primary, btn-danger, etc) to custom commands. This change is necessary because without it, the styling functionality of this plugin will not work: https://github.com/Salandora/octoprint-customControl

The changes in the PR are not achievable by a plugin.

#### How was it tested? How can it be tested by the reviewer?
I didn't use unit tests, however I tested it with a command that didn't have the customClass property and the class was set as expected **class=btn**. I also tested it with the plugin referenced above for commands with customClass defined

#### Any background context you want to provide?
I don't know if adding custom classes to controls are a highly sought after feature, but I wanted to add a control that applied heat to the printer bed and nozzle, and I wanted to make it red. So, it would be useful to me!

#### What are the relevant tickets if any?
N/A

#### Screenshots (if appropriate)
![screen shot 2018-02-22 at 12 27 55 am](https://user-images.githubusercontent.com/7546899/36525465-5cc7e3f8-1767-11e8-9fbe-544595335251.png)

#### Further notes
I am new to OctoPrint, as well as Knockout, but my intentions were to check for the customClass property and if it didn't exist, to style the button with the same styling before my changes. This way, my code shouldn't conflict with any other code/plugins that don't use custom classes.