### PR TITLE
Add a confirmation if disconnecting while printing

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/connection.js
+++ b/src/octoprint/static/js/app/viewmodels/connection.js
@@ -125,8 +125,24 @@ $(function() {
                         self.settings.printerProfiles.requestData();
                     });
             } else {
-                self.requestData();
-                OctoPrint.connection.disconnect();
+                if (!self.isPrinting() && !self.isPaused()) {
+                    self.requestData();
+                    OctoPrint.connection.disconnect();
+                } else {
+                    showConfirmationDialog({
+                        title: gettext("Are you sure?"),
+                        message: gettext("<p><strong>You are about to disconnect from the printer while a print is in progress.</strong></p> \
+                            <p>Disconnecting while a print is in progress will prevent OctoPrint from completing the print. If you're printing from an SD card attached directly to the printer, any attempt to restart OctoPrint or reconnect to the printer could interrupt the print.<p>"),
+                        question: gettext("Are you sure you want to disconnect from the printer?"),
+                        cancel: gettext("Stay Connected"),
+                        proceed: gettext("Disconnect"),
+                        onproceed:  function() {
+                            self.requestData();
+                            OctoPrint.connection.disconnect();
+                        }
+                    })
+                }
+                
             }
         };
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Add a confirmation dialog if a user attempts to disconnect from the printer while a print
is in progress

#### How was it tested? How can it be tested by the reviewer?
* Connect to a printer
* Start a print
* Attempt to disconnect from the printer's serial connection
* Additionally, pause the print and attempt to disconnect
* Observe in both cases a dialog box should appear, asking a user if they wish to disconnect while a print is in progess.

#### Any background context you want to provide?
Fulfilling a feature request. Discussions were had about adding the ability to disable this confirmation, however I believe disconnecting while a print is in progress should be such a rare occurrence that the ability to bypass the confirmation is unnecessary.
#### What are the relevant tickets if any?
https://github.com/foosel/OctoPrint/issues/2287

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/9030085/37092356-4f7bbc7e-2257-11e8-834c-01d00b473bcb.png)

#### Further notes
