### PR TITLE
Fix buttons not disabled when there isn't an API key available

### DIFF
--- a/src/octoprint/templates/dialogs/settings/api.jinja2
+++ b/src/octoprint/templates/dialogs/settings/api.jinja2
@@ -18,8 +18,8 @@
         <div class="controls">
             <div class="input-append input-block-level">
                 <input type="text" readonly="readonly" id="settings-apikey" data-bind="value: api_key, attr: {placeholder: '{{ _('N/A') }}'}">
-                <a class="btn add-on" title="Copy API Key to clipboard" data-bind="click: copyApiKey, enable: api_key"><i class="fa fa-copy"></i></a>
-                <a class="btn add-on" title="Generate new API Key" data-bind="click: generateApiKey, enable: api_key"><i class="fa fa-refresh"></i></a>
+                <a class="btn add-on" title="Copy API Key to clipboard" data-bind="click: copyApiKey, css: {'disabled': !api_key()}"><i class="fa fa-copy"></i></a>
+                <a class="btn add-on" title="Generate new API Key" data-bind="click: generateApiKey"><i class="fa fa-refresh"></i></a>
             </div>
             <span class="help-block">{{ _('Please note that changes to the API key are applied immediately, without having to "Save" first.') }}</span>
         </div>

--- a/src/octoprint/templates/dialogs/usersettings/access.jinja2
+++ b/src/octoprint/templates/dialogs/usersettings/access.jinja2
@@ -25,9 +25,9 @@
             <div class="controls">
                 <div class="input-append input-block-level">
                     <input type="text" readonly="readonly" id="userSettings-access_apikey" data-bind="value: access_apikey, attr: {placeholder: '{{ _('N/A') }}'}">
-                    <a class="btn add-on" title="Copy API Key to clipboard" data-bind="click: copyApikey, enable: access_apikey"><i class="fa fa-copy"></i></a>
+                    <a class="btn add-on" title="Copy API Key to clipboard" data-bind="click: copyApikey, css: {'disabled': !access_apikey()}"><i class="fa fa-copy"></i></a>
                     <a class="btn add-on" title="Generate new API Key" data-bind="click: generateApikey"><i class="fa fa-refresh"></i></a>
-                    <a class="btn btn-danger add-on" title="Delete API Key" data-bind="click: deleteApikey, enable: access_apikey"><i class="fa fa-trash-o"></i></a>
+                    <a class="btn btn-danger add-on" title="Delete API Key" data-bind="click: deleteApikey, css: {'disabled': !access_apikey()}"><i class="fa fa-trash-o"></i></a>
                 </div>
                 <span class="help-block">{{ _('Please note that changes to the API key are applied immediately, without having to "Confirm" first.') }}</span>
             </div>


### PR DESCRIPTION
Bootstrap buttons made from HTML `<a>` tags can only be disabled with CSS.

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

The buttons to copy the API key to the clipboard and to delete the user key aren't disabled when the input box shows "N/A" because the knockout.js code attached to them uses the `disabled` attribute which works only for `<button>` and `<input>` elements, not for '<a>'.

#### How was it tested? How can it be tested by the reviewer?

To test the user key, delete it with the "trash" button and see if the buttons change appearance.
To test the global key I edited the HTML by hand.

#### Any background context you want to provide?

I would have preferred to change only the HTML from `<a>` to`<button>` but this breaks the layout in many ways.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

* Before
![image](https://user-images.githubusercontent.com/1055635/38165355-4f6dd7c6-3512-11e8-8249-38db70754db2.png)

* After
![image](https://user-images.githubusercontent.com/1055635/38165183-e1efeb32-350f-11e8-96b2-f94bbbc8c73f.png)

* Before
![image](https://user-images.githubusercontent.com/1055635/38165332-09905abc-3512-11e8-8a91-b70826be8369.png)

* After
![image](https://user-images.githubusercontent.com/1055635/38165212-6a6c40f0-3510-11e8-993b-9a78f87392c7.png)

#### Further notes

This bug was present in 1.3.6.

Note that I'm only fixing the visual aspect with this PR, but I'd rather change the behavior by keeping always enabled the button to regenerate the global API key, just like it is done for the user key.
The last image shows that if this PR is merged, it wouldn't be possible to manually generate a new global API key if one is missing; I understand that OctoPrint will create a missing key on start, but this user interface doesn't need to depend on that.