### PR TITLE
Pip install with --no-cache-dir to handle plugin installations with M…

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -88,6 +88,7 @@ date of first contribution):
   * [Josh Major](https://github.com/astateofblank)
   * ["alex-gh"](https://github.com/alex-gh)
   * [Bernd Zeimetz](https://github.com/bzed)
+  * [Ganey](https://github.com/ganey)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -333,7 +333,7 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 			raise ValueError("Either URL or path must be provided")
 
 		self._logger.info("Installing plugin from {}".format(source))
-		pip_args = ["install", sarge.shell_quote(source)]
+		pip_args = ["install", sarge.shell_quote(source), '--no-cache-dir']
 
 		if dependency_links or self._settings.get_boolean(["dependency_links"]):
 			pip_args.append("--process-dependency-links")


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

On older RasperryPi's various plugins will not install with pip and fail with 'MemoryError'.
This occurs particularly with plugins that use `Pillow`

#### How was it tested? How can it be tested by the reviewer?

Via current unit tests for breakages.

#### What are the relevant tickets if any?

https://github.com/FormerLurker/Octolapse/issues/107

#### Further notes

Please see ticket for logs detailing previous installation issues. 

Happy to discuss this further, Python isn't my strongest language, so happy to edit this if required. So far haven't had any issues running a fork on AnetA8 running marlin with this PR.
