### PR TITLE
Add link to instructions to reset passwords

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -87,6 +87,7 @@ date of first contribution):
   * [Josh Major](https://github.com/astateofblank)
   * ["alex-gh"](https://github.com/alex-gh)
   * [Bernd Zeimetz](https://github.com/bzed)
+  * [Daniele Forsi](https://github.com/dforsi)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/templates/dialogs/forgot_password.jinja2
+++ b/src/octoprint/templates/dialogs/forgot_password.jinja2
@@ -1,0 +1,12 @@
+<div id="forgot_password_dialog" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="forgot_password_dialog_label" aria-hidden="true">
+  <div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal">&times;</button>
+    <h3 id="forgot_password_dialog_label">{{ _('Forgot password?') }}</h3>
+  </div>
+  <div class="modal-body">
+    <p>{{ _('See detailed instructions at <a href="https://discourse.octoprint.org/t/i-forgot-my-octoprint-password-how-can-i-reset-it/215">I forgot my OctoPrint password, how can I reset it?</a>') }}</p>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-block" data-dismiss="modal" aria-hidden="true">{{ _('Close') }}</button>
+  </div>
+</div>

--- a/src/octoprint/templates/navbar/login.jinja2
+++ b/src/octoprint/templates/navbar/login.jinja2
@@ -6,6 +6,7 @@
     <form id="loginForm" data-bind="event: {'submit': loginState.prepareLogin }" onsubmit="return false; // this gets overwritten on view model bind">
         <label for="login_user">{{ _('Username') }}</label>
         <input type="text" id="login_user" name="username" data-bind="valueWithInit: loginState.loginUser" placeholder="{{ _('Username') }}" autocapitalize="none" autocorrect="off">
+        <span class="pull-right"><small><a href="#forgot_password_dialog" data-toggle="modal">{{ _('Forgot password?') }}</a></small></span>
         <label for="login_pass">{{ _('Password') }}</label>
         <input type="password" id="login_pass" name="password" data-bind="valueWithInit: loginState.loginPass" placeholder="{{ _('Password') }}">
         <label class="checkbox">
@@ -18,3 +19,5 @@
     <li><a href="#" id="usersettings_button" data-bind="click: function() { usersettings.show(); }">{{ _('User Settings') }}</a></li>
     <li><a href="#" id="logout_button" data-bind="click: loginState.logout">{{ _('Logout') }}</a></li>
 </ul>
+
+{% include 'dialogs/forgot_password.jinja2' %}


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
It helps users who forgot their password.

#### How was it tested? How can it be tested by the reviewer?
Manually click the link and interact with the dialog.

#### Any background context you want to provide?

#### What are the relevant tickets if any?
#1239
#### Screenshots (if appropriate)

This PR adds a link to the right of the "Password" label:
![image](https://user-images.githubusercontent.com/1055635/38218327-a4e4b114-36d1-11e8-9108-371e0588f2b2.png)

The link opens a modal dialog (with only a single line of text, at this moment):
![image](https://user-images.githubusercontent.com/1055635/38217977-906fd64c-36d0-11e8-9690-c7b2ef9b9f84.png)

#### Further notes

For the dialog I used the same style as the About dialog (ie. close icon at top right and big button in the footer).

The link points to the external address https://discourse.octoprint.org/t/i-forgot-my-octoprint-password-how-can-i-reset-it/215 I didn't add the full text because it doesn't seem too clear to me, eg. the part "If you have multiple users configured" seems related to OS X only.

There are at least 3 positions where the link could be put (I prefer position 1):
![image](https://user-images.githubusercontent.com/1055635/38218031-bf8dcec0-36d0-11e8-829f-cc77fe7f4afc.png)
