### PR TITLE
Pip install with --no-cache-dir to handle plugin installations with MemoryError

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -87,6 +87,7 @@ date of first contribution):
   * [Josh Major](https://github.com/astateofblank)
   * ["alex-gh"](https://github.com/alex-gh)
   * [Bernd Zeimetz](https://github.com/bzed)
+  * [Ganey](https://github.com/ganey)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -333,7 +333,7 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 			raise ValueError("Either URL or path must be provided")
 
 		self._logger.info("Installing plugin from {}".format(source))
-		pip_args = ["install", sarge.shell_quote(source)]
+		pip_args = ["install", sarge.shell_quote(source), '--no-cache-dir']
 
 		if dependency_links or self._settings.get_boolean(["dependency_links"]):
 			pip_args.append("--process-dependency-links")


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Fixes installations of pip plugins which throw a MemoryError on low memory devices.

See https://github.com/foosel/OctoPrint/pull/2535 for more info

> This error is coming up because, it seems, pip's caching mechanism is trying to read the entire file into memory before caching it… which poses a problem in a limited-memory environment, as matplotlib is ~50mb.
