### PR TITLE
docfix: make 'settings' proper yaml

### DIFF
--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -151,7 +151,7 @@ appearance or to modify the order and presence of the various UI components:
 
          # order of settings, if settings plugins are registered gets extended internally by
          # section_plugins and all settings plugins
-         settings
+         settings:
          - section_printer
          - serial
          - printerprofiles


### PR DESCRIPTION
See PR #2530; I assumed it should go into 'devel' so it is right in new releases, but Gina asked for it to be done here.

refusing to fill out the template for a docfix :)
