### PR TITLE
Add M118 to commands to not uppercase

### DIFF
--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -560,6 +560,7 @@ Use the following settings to enable or disable OctoPrint features:
      # Defaults to only M117.
      autoUppercaseBlacklist:
      - M117
+     - M118
 
 .. _sec-configuration-config_yaml-folder:
 

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -238,7 +238,7 @@ default_settings = {
 		"pollWatched": False,
 		"modelSizeDetection": True,
 		"printCancelConfirmation": True,
-		"autoUppercaseBlacklist": ["M117"],
+		"autoUppercaseBlacklist": ["M117", "M118"],
 		"g90InfluencesExtruder": False
 	},
 	"folder": {


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
`M118` is a gcode command which will echo output to the serial console (like `M117`, but output to serial rather than the LCD).

It's probably not common to want to use `M118` in the OctoPrint terminal, but if it is used the user probably expects the case to be preserved.

This PR adds `M118` to the default list of commands which should not automatically be converted to uppercase so that the case entered on the command line is preserved.

#### How was it tested? How can it be tested by the reviewer?
To be honest, I'm not 100% sure how to test the change.  Would i need to do a fresh install of OctoPrint to see the change appear in the defaults?  I _think_ I've changed both places where it was necessary to add `M118`.

I can certainly confirm that adding `M118` to the list of ignored commands fixes issues I was having with my `M118` commands being automatically converted to uppercase.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
There are other `M` commands in Marlin which are used to interact with files on the SD card.  These commands may expect to have the case of the filename preserved, I'm not sure.  Those commands are M23, M28, M30, and M928 (there may be more).  It might be worth also blacklisting these commands by default.