### PR TITLE
User info for print job

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -89,6 +89,7 @@ date of first contribution):
   * [Bernd Zeimetz](https://github.com/bzed)
   * [Daniele Forsi](https://github.com/dforsi)
   * [Ganey](https://github.com/ganey)
+  * [Sven Lohrmann](https://github.com/malnvenshorn)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -65,6 +65,8 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
 		self._state = None
 
+		self._printingUser = None
+
 		self._currentZ = None
 
 		self._printAfterSelect = False
@@ -418,7 +420,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 		self.commands("M221 S%d" % factor,
 		              tags=kwargs.get("tags", set()) | {"trigger:printer.flow_rate"})
 
-	def select_file(self, path, sd, printAfterSelect=False, pos=None, *args, **kwargs):
+	def select_file(self, path, sd, printAfterSelect=False, user=None, pos=None, *args, **kwargs):
 		if self._comm is None or (self._comm.isBusy() or self._comm.isStreaming()):
 			self._logger.info("Cannot load file: printer not connected or currently busy")
 			return
@@ -436,6 +438,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 				self._fileManager.delete_recovery_data()
 
 		self._printAfterSelect = printAfterSelect
+		self._printingUser = user
 		self._posAfterSelect = pos
 		self._comm.selectFile("/" + path if sd else path, sd,
 		                      tags=kwargs.get("tags", set()) | {"trigger:printer.select_file"})
@@ -460,7 +463,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
 		return self._comm.getFilePosition()
 
-	def start_print(self, pos=None, *args, **kwargs):
+	def start_print(self, pos=None, user=None, *args, **kwargs):
 		"""
 		 Starts the currently loaded print job.
 		 Only starts if the printer is connected and operational, not currently printing and a printjob is loaded
@@ -493,6 +496,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 		self._lastProgressReport = None
 		self._updateProgressData()
 		self._setCurrentZ(None)
+		self._setPrintingUser(user)
 		self._comm.startPrint(pos=pos,
 		                      tags=kwargs.get("tags", set()) | {"trigger:printer.start_print"})
 
@@ -995,6 +999,9 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 			                                           lastPrintTime=lastPrintTime,
 			                                           filament=filament))
 
+	def _setPrintingUser(self, user):
+		self._stateMonitor.set_printing_user(user)
+
 	def _sendInitialStateUpdate(self, callback):
 		try:
 			data = self._stateMonitor.get_current_data()
@@ -1130,7 +1137,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
 		if self._printAfterSelect:
 			self._printAfterSelect = False
-			self.start_print(pos=self._posAfterSelect)
+			self.start_print(pos=self._posAfterSelect, user=self._printingUser)
 
 	def on_comm_print_job_started(self):
 		payload = self._payload_for_print_job_event()
@@ -1142,6 +1149,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
 	def on_comm_print_job_done(self):
 		self._fileManager.delete_recovery_data()
+		self._setPrintingUser(None)
 
 		payload = self._payload_for_print_job_event()
 		if payload:
@@ -1175,6 +1183,8 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
 
 	def on_comm_print_job_failed(self):
+		self._setPrintingUser(None)
+
 		payload = self._payload_for_print_job_event()
 		if payload:
 			eventManager().fire(Events.PRINT_FAILED, payload)
@@ -1189,6 +1199,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 	def on_comm_print_job_cancelled(self):
 		self._setCurrentZ(None)
 		self._updateProgressData()
+		self._setPrintingUser(None)
 
 		payload = self._payload_for_print_job_event(position=self._comm.cancel_position.as_dict() if self._comm and self._comm.cancel_position else None)
 		if payload:
@@ -1322,6 +1333,7 @@ class StateMonitor(object):
 		self._current_z = None
 		self._offsets = dict()
 		self._progress = None
+		self._printing_user = None
 
 		self._progress_dirty = False
 
@@ -1339,12 +1351,13 @@ class StateMonitor(object):
 			return self._on_get_progress()
 		return self._progress
 
-	def reset(self, state=None, job_data=None, progress=None, current_z=None, offsets=None):
+	def reset(self, state=None, job_data=None, progress=None, current_z=None, offsets=None, printing_user=None):
 		self.set_state(state)
 		self.set_job_data(job_data)
 		self.set_progress(progress)
 		self.set_current_z(current_z)
 		self.set_temp_offsets(offsets)
+		self.set_printing_user(printing_user)
 
 	def add_temperature(self, temperature):
 		self._on_add_temperature(temperature)
@@ -1369,6 +1382,10 @@ class StateMonitor(object):
 
 	def set_job_data(self, job_data):
 		self._job_data = job_data
+		self._change_event.set()
+
+	def set_printing_user(self, user):
+		self._printing_user = user
 		self._change_event.set()
 
 	def trigger_progress_update(self):
@@ -1415,7 +1432,8 @@ class StateMonitor(object):
 			"job": self._job_data,
 			"currentZ": self._current_z,
 			"progress": self._progress,
-			"offsets": self._offsets
+			"offsets": self._offsets,
+			"printingUser": self._printing_user,
 		}
 
 

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -9,7 +9,7 @@ from flask import request, jsonify, make_response, url_for
 
 from octoprint.filemanager.destinations import FileDestinations
 from octoprint.settings import settings, valid_boolean_trues
-from octoprint.server import printer, fileManager, slicingManager, eventManager, NO_CONTENT
+from octoprint.server import printer, fileManager, slicingManager, eventManager, NO_CONTENT, current_user
 from octoprint.server.util.flask import restricted_access, get_json_command_from_request, with_revalidation_checking
 from octoprint.server.api import api
 from octoprint.events import Events
@@ -316,6 +316,8 @@ def uploadGcodeFile(target):
 
 		reselect = printer.is_current_file(futureFullPathInStorage, sd)
 
+		user = current_user.get_name()
+
 		def fileProcessingFinished(filename, absFilename, destination):
 			"""
 			Callback for when the file processing (upload, optional slicing, addition to analysis queue) has
@@ -340,7 +342,7 @@ def uploadGcodeFile(target):
 			exact file is already selected, such reloading it.
 			"""
 			if octoprint.filemanager.valid_file_type(added_file, "gcode") and (selectAfterUpload or printAfterSelect or reselect):
-				printer.select_file(absFilename, destination == FileDestinations.SDCARD, printAfterSelect)
+				printer.select_file(absFilename, destination == FileDestinations.SDCARD, printAfterSelect, user)
 
 		try:
 			added_file = fileManager.add_file(FileDestinations.LOCAL, futureFullPathInStorage, upload,
@@ -485,6 +487,8 @@ def gcodeFileCommand(filename, target):
 	if response is not None:
 		return response
 
+	user = current_user.get_name()
+
 	if command == "select":
 		if not _verifyFileExists(target, filename):
 			return make_response("File not found on '%s': %s" % (target, filename), 404)
@@ -505,7 +509,7 @@ def gcodeFileCommand(filename, target):
 			sd = True
 		else:
 			filenameToSelect = fileManager.path_on_disk(target, filename)
-		printer.select_file(filenameToSelect, sd, printAfterLoading)
+		printer.select_file(filenameToSelect, sd, printAfterLoading, user)
 
 	elif command == "slice":
 		if not _verifyFileExists(target, filename):
@@ -608,7 +612,7 @@ def gcodeFileCommand(filename, target):
 					sd = True
 				else:
 					filenameToSelect = fileManager.path_on_disk(target, path)
-				printer.select_file(filenameToSelect, sd, print_after_slicing)
+				printer.select_file(filenameToSelect, sd, print_after_slicing, user)
 
 		try:
 			fileManager.slice(slicer, target, filename, target, full_path,

--- a/src/octoprint/server/api/job.py
+++ b/src/octoprint/server/api/job.py
@@ -7,7 +7,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 
 from flask import request, make_response, jsonify
 
-from octoprint.server import printer, NO_CONTENT
+from octoprint.server import printer, NO_CONTENT, current_user
 from octoprint.server.util.flask import restricted_access, get_json_command_from_request
 from octoprint.server.api import api
 import octoprint.util as util
@@ -34,14 +34,16 @@ def controlJob():
 
 	tags = {"source:api", "api:job"}
 
+	user = current_user.get_name()
+
 	if command == "start":
 		if activePrintjob:
 			return make_response("Printer already has an active print job, did you mean 'restart'?", 409)
-		printer.start_print(tags=tags)
+		printer.start_print(tags=tags, user=user)
 	elif command == "restart":
 		if not printer.is_paused():
 			return make_response("Printer does not have an active print job or is not paused", 409)
-		printer.start_print(tags=tags)
+		printer.start_print(tags=tags, user=user)
 	elif command == "pause":
 		if not activePrintjob:
 			return make_response("Printer is neither printing nor paused, 'pause' command cannot be performed", 409)
@@ -67,5 +69,6 @@ def jobState():
 	return jsonify({
 		"job": currentData["job"],
 		"progress": currentData["progress"],
-		"state": currentData["state"]["text"]
+		"state": currentData["state"]["text"],
+		"printingUser": currentData["printingUser"],
 	})


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Adding user information to the printer state so it is possible to retrieve the user who started the current print job. This is a useful information in a multi-user environment. A use case might be a print history where the admin can see who used the printer, e.g. for billing purposes.

#### How was it tested? How can it be tested by the reviewer?

Started print in the web interface and checked the `printingUser` with the job API. 
Confirmed that the `printingUser` was set the null after the print finished/failed/was cancelled.
Also tested the same with 'print after loading'. 
Haven't tested with 'print after slicing'.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#652
#1545

#### Screenshots (if appropriate)

#### Further notes

Applied changes you mentioned in #2570. Opened a new PR because I used the `devel` branch for my changes in the previous PR.
