### PR TITLE
Reload older values after cancelling the Settings dialog

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -886,6 +886,13 @@ $(function() {
             firstRequest.resolve();
         };
 
+        self.cancelData = function () {
+            // revert unsaved changes
+            self.fromResponse(self.lastReceivedSettings);
+
+            self.hide();
+        }
+
         self.saveData = function (data, successCallback, setAsSending) {
             var options;
             if (_.isPlainObject(successCallback)) {

--- a/src/octoprint/templates/dialogs/settings.jinja2
+++ b/src/octoprint/templates/dialogs/settings.jinja2
@@ -49,7 +49,7 @@
     </div>
     <div class="modal-footer">
         <button class="btn aboutlink" data-bind="click: about.show"><i class="fa fa-info-circle"></i> {{ _('About OctoPrint') }}</button>
-        <button class="btn" data-dismiss="modal" aria-hidden="true">{{ _('Cancel') }}</button>
+        <button class="btn" data-bind="click: function() { cancelData() }" aria-hidden="true">{{ _('Cancel') }}</button>
         <button class="btn btn-primary" data-bind="click: function() { saveData(undefined, $root.hide) }, enable: !exchanging(), css: {disabled: exchanging()}"><i class="fa fa-spinner fa-spin" data-bind="visible: sending"></i> {{ _('Save') }}</button>
     </div>
 </div>


### PR DESCRIPTION
Fixes #2534

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a bug reported in #2534 that caused unsaved values to be shown after cancelling the Settings dialog.

#### How was it tested? How can it be tested by the reviewer?

1. open the Settings dialog
1. modify one or more settings
1. press the Cancel button
1. open the Settings dialog again
1. see that the settings modified at step 2 are lost and the old values are shown

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#2534

#### Screenshots (if appropriate)

#### Further notes
