### PR TITLE
Keep the Connection pane in sync with the Settings

### DIFF
--- a/src/octoprint/server/api/connection.py
+++ b/src/octoprint/server/api/connection.py
@@ -78,8 +78,8 @@ def _get_options():
 	default_profile = printerProfileManager.get_default()
 
 	options = dict(
-		ports=sorted(connection_options["ports"]),
-		baudrates=sorted(connection_options["baudrates"], reverse=True),
+		ports=connection_options["ports"],
+		baudrates=connection_options["baudrates"],
 		printerProfiles=[dict(id=printer_profile["id"], name=printer_profile["name"] if "name" in printer_profile else printer_profile["id"]) for printer_profile in profile_options.values() if "id" in printer_profile],
 		portPreference=connection_options["portPreference"],
 		baudratePreference=connection_options["baudratePreference"],

--- a/src/octoprint/static/js/app/viewmodels/connection.js
+++ b/src/octoprint/static/js/app/viewmodels/connection.js
@@ -151,6 +151,10 @@ $(function() {
             }
         };
 
+        self.onEventSettingsUpdated = function() {
+            self.requestData();
+        }
+
         self.onStartup = function() {
             var connectionTab = $("#connection");
             connectionTab.on("show", function() {


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

1. Return the Serial Port and the Baudrate lists without sorting them.
1. Refresh the list of serial ports and baud rates in the Connection pane when the corresponding settings are updated

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#2539 

#### Screenshots (if appropriate)

#### Further notes

This PR doesn't fix the another problem reported in #2539 (Settings dialog not updated when "Save connection settings" is checked in the Connection pane until manually refreshed).