### PR TITLE
ItemListHelper - Save page size to local storage

### DIFF
--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -326,7 +326,7 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
 
     self._loadPageSizeFromLocalStorage = function() {
         if (self._initializeLocalStorage) {
-            self.pageSize(localStorage[self.storageIds.pageSize]);
+            self.pageSize(parseInt(localStorage[self.storageIds.pageSize]));
         }
     }
 

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -1,4 +1,4 @@
-function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSorting, defaultFilters, exclusiveFilters, filesPerPage) {
+function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSorting, defaultFilters, exclusiveFilters, defaultPageSize) {
     var self = this;
 
     self.listType = listType;
@@ -7,6 +7,7 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
     self.defaultSorting = defaultSorting;
     self.defaultFilters = defaultFilters;
     self.exclusiveFilters = exclusiveFilters;
+    self.defaultPageSize = defaultPageSize;
 
     self.searchFunction = undefined;
 
@@ -14,7 +15,7 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
     self.allSize = ko.observable(0);
 
     self.items = ko.observableArray([]);
-    self.pageSize = ko.observable(filesPerPage);
+    self.pageSize = ko.observable(self.defaultPageSize);
     self.currentPage = ko.observable(0);
     self.currentSorting = ko.observable(self.defaultSorting);
     self.currentFilters = ko.observableArray(self.defaultFilters);
@@ -23,6 +24,7 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
     self.storageIds = {
         "currentSorting": self.listType + "." + "currentSorting",
         "currentFilters": self.listType + "." + "currentFilters",
+        "pageSize": self.listType + "." + "pageSize",
     };
 
     //~~ item handling
@@ -314,21 +316,37 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
         }
     };
 
+    self._savePageSizeToLocalStorage = function(pageSize) {
+        if (self._initializeLocalStorage()) {
+            localStorage[self.storageIds.pageSize] = pageSize;
+        }
+    }
+
+    self.pageSize.subscribe(self._savePageSizeToLocalStorage);
+
+    self._loadPageSizeFromLocalStorage = function() {
+        if (self._initializeLocalStorage) {
+            self.pageSize(localStorage[self.storageIds.pageSize]);
+        }
+    }
+
     self._initializeLocalStorage = function() {
         if (!Modernizr.localstorage)
             return false;
 
-        if (localStorage[self.storageIds.currentSorting] !== undefined && localStorage[self.storageIds.currentFilters] !== undefined && JSON.parse(localStorage[self.storageIds.currentFilters]) instanceof Array)
+        if (localStorage[self.storageIds.currentSorting] !== undefined && localStorage[self.storageIds.currentFilters] !== undefined && JSON.parse(localStorage[self.storageIds.currentFilters]) instanceof Array && localStorage[self.storageIds.pageSize] !== undefined)
             return true;
 
         localStorage[self.storageIds.currentSorting] = self.defaultSorting;
         localStorage[self.storageIds.currentFilters] = JSON.stringify(self.defaultFilters);
+        localStorage[self.storageIds.pageSize] = self.defaultPageSize;
 
         return true;
     };
 
     self._loadCurrentFiltersFromLocalStorage();
     self._loadCurrentSortingFromLocalStorage();
+    self._loadPageSizeFromLocalStorage();
 }
 
 function formatSize(bytes) {

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -20,6 +20,11 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
     self.currentFilters = ko.observableArray(self.defaultFilters);
     self.selectedItem = ko.observable(undefined);
 
+    self.storageIds = {
+        "currentSorting": self.listType + "." + "currentSorting",
+        "currentFilters": self.listType + "." + "currentFilters",
+    };
+
     //~~ item handling
 
     self.refresh = function() {
@@ -281,16 +286,16 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
         if ( self._initializeLocalStorage() ) {
             var currentSorting = self.currentSorting();
             if (currentSorting !== undefined)
-                localStorage[self.listType + "." + "currentSorting"] = currentSorting;
+                localStorage[self.storageIds.currentSorting] = currentSorting;
             else
-                localStorage[self.listType + "." + "currentSorting"] = undefined;
+                localStorage[self.storageIds.currentSorting] = undefined;
         }
     };
 
     self._loadCurrentSortingFromLocalStorage = function() {
         if ( self._initializeLocalStorage() ) {
-            if (_.contains(_.keys(supportedSorting), localStorage[self.listType + "." + "currentSorting"]))
-                self.currentSorting(localStorage[self.listType + "." + "currentSorting"]);
+            if (_.contains(_.keys(supportedSorting), localStorage[self.storageIds.currentSorting]))
+                self.currentSorting(localStorage[self.storageIds.currentSorting]);
             else
                 self.currentSorting(defaultSorting);
         }
@@ -299,13 +304,13 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
     self._saveCurrentFiltersToLocalStorage = function() {
         if ( self._initializeLocalStorage() ) {
             var filters = _.intersection(_.keys(self.supportedFilters), self.currentFilters());
-            localStorage[self.listType + "." + "currentFilters"] = JSON.stringify(filters);
+            localStorage[self.storageIds.currentFilters] = JSON.stringify(filters);
         }
     };
 
     self._loadCurrentFiltersFromLocalStorage = function() {
         if ( self._initializeLocalStorage() ) {
-            self.currentFilters(_.intersection(_.keys(self.supportedFilters), JSON.parse(localStorage[self.listType + "." + "currentFilters"])));
+            self.currentFilters(_.intersection(_.keys(self.supportedFilters), JSON.parse(localStorage[self.storageIds.currentFilters])));
         }
     };
 
@@ -313,11 +318,11 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
         if (!Modernizr.localstorage)
             return false;
 
-        if (localStorage[self.listType + "." + "currentSorting"] !== undefined && localStorage[self.listType + "." + "currentFilters"] !== undefined && JSON.parse(localStorage[self.listType + "." + "currentFilters"]) instanceof Array)
+        if (localStorage[self.storageIds.currentSorting] !== undefined && localStorage[self.storageIds.currentFilters] !== undefined && JSON.parse(localStorage[self.storageIds.currentFilters]) instanceof Array)
             return true;
 
-        localStorage[self.listType + "." + "currentSorting"] = self.defaultSorting;
-        localStorage[self.listType + "." + "currentFilters"] = JSON.stringify(self.defaultFilters);
+        localStorage[self.storageIds.currentSorting] = self.defaultSorting;
+        localStorage[self.storageIds.currentFilters] = JSON.stringify(self.defaultFilters);
 
         return true;
     };


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Was wondering why the `ItemListHelper` saves the current sorting and filtering to the local storage but not the page size, so I changed that. I wouldn't call this a necessary change, since a developer can provide his own implementation to achieve the same behavior. Therefore it's ok if you don't merge this PR.

#### How was it tested? How can it be tested by the reviewer?

Tested with my FilamentManager plugin.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
