### PR TITLE
Allow class methods as callbacks in view model

### DIFF
--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -1103,7 +1103,7 @@ function callViewModelIf(viewModel, method, condition, callback, raiseErrors) {
         condition = function() { return true; };
     }
 
-    if (!viewModel.hasOwnProperty(method) || !_.isFunction(viewModel[method]) || !condition(viewModel, method)) return;
+    if (!_.isFunction(viewModel[method]) || !condition(viewModel, method)) return;
 
     var parameters = undefined;
     if (!_.isFunction(callback)) {


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

At the moment a callback in the view model, e.g. `onStartup()`  must be a property of the object. Some example:
```
class MyViewModel {

  constructor() {
    this.onStartupComplete = () => {
      // gets called
    };
  }

  onStartup() {
    // doesn't get called
  }
}
```
Therefore I removed the check for the property. The change does no harm, because `_.isFunction(undefined)` is false.

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
