### PR TITLE
Fix greyed plugin manager delete icons still being clickable

### DIFF
--- a/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
+++ b/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
@@ -587,7 +587,7 @@ $(function() {
                 return;
             }
 
-            if (!self.enableManagement()) {
+            if (!self.enableUninstall(data)) {
                 return;
             }
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Fixes the initial issue https://github.com/foosel/OctoPrint/issues/2549 where a greyed delete icon was still able to be clicked

#### How was it tested? How can it be tested by the reviewer?

Tested by clicking on various delete icons within the plugin manager. Plugins with padlocks that are *not* bundled with OctoPrint are no longer able to be clicked on. Other functionality appears to remain unchanged.

#### Any background context you want to provide?

The plugin that brought this to my attention is a plugin with "broken" permissions. OctoPrint has no authority to remove it, OctoPrint knows this and displays a padlock icon and greys out the delete button, however previously that greyed delete button was still a clickable item. Unfortunately I'm not sure how I broke the plugin's permissions in order to replicate that (although I do still have the plugin installed to test against).

#### What are the relevant tickets if any?

https://github.com/foosel/OctoPrint/issues/2549

#### Screenshots (if appropriate)

This PR doesn't make any visual changes, however a screenshot summary of the issue is included in the issue ticket.

#### Further notes

The original call was to ``if (!self.enableManagement()) { ... }`` and since that appears to only check whether the printer is printing, the change to ``if (!self.enableUninstall(data)) { ... }`` was made, which appears to also check against permissions in addition to print status. ``if (!self.enableUninstall(data)) { ... }`` also calls the ``self.enableManagement()`` function, so I don't believe the overall behaviour of the plugin uninstaller will change. All of my own testing suggests this to be the case.

This pull request does **not** handle the final issue identified in the ticket, where when OctoPrint is in safe mode the plugin manager fails to identify plugins that have been uninstalled.