### PR TITLE
estimatedPrintTime is in seconds, not minutes

### DIFF
--- a/src/octoprint/filemanager/analysis.py
+++ b/src/octoprint/filemanager/analysis.py
@@ -299,7 +299,7 @@ class GcodeAnalysisQueue(AbstractAnalysisQueue):
 	   - * **Key**
 	     * **Description**
 	   - * ``estimatedPrintTime``
-	     * Estimated time the file take to print, in minutes
+	     * Estimated time the file take to print, in seconds
 	   - * ``filament``
 	     * Substructure describing estimated filament usage. Keys are ``tool0`` for the first extruder, ``tool1`` for
 	       the second and so on. For each tool extruded length and volume (based on diameter) are provided.


### PR DESCRIPTION
The documentation says that the estimated print time should be given in minute.  But in practice, when I give it in minutes, the GUI shows an error factor of 60.  By supplying it in seconds, the correct value is shown.

So it should probably actually be "in seconds"

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

The comment about estimatedPrintTime was wrong, it says minutes but it should be seconds

#### How was it tested? How can it be tested by the reviewer?

I uploaded a file using a slicer that reports estimatedPrintTime and I observed the the GUI displays seconds, not minutes.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
