### PR TITLE
Always run the GCodeAnalyser, even if the slicer provided analysis

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ trim_trailing_whitespace = true
 
 [**.py]
 indent_style = tab
+indent_size = 4
 
 [src/octoprint/static/js/app/**.js]
 indent_style = space

--- a/src/octoprint/filemanager/analysis.py
+++ b/src/octoprint/filemanager/analysis.py
@@ -20,7 +20,7 @@ from octoprint.events import Events, eventManager
 from octoprint.settings import settings
 
 
-class QueueEntry(collections.namedtuple("QueueEntry", "name, path, type, location, absolute_path, printer_profile")):
+class QueueEntry(collections.namedtuple("QueueEntry", "name, path, type, location, absolute_path, printer_profile, analysis")):
 	"""
 	A :class:`QueueEntry` for processing through the :class:`AnalysisQueue`. Wraps the entry's properties necessary
 	for processing.
@@ -33,6 +33,7 @@ class QueueEntry(collections.namedtuple("QueueEntry", "name, path, type, locatio
 	    location (str): Location the file is located on.
 	    absolute_path (str): Absolute path on disk through which to access the file.
 	    printer_profile (PrinterProfile): :class:`PrinterProfile` which to use for analysis.
+	    analysis (dict): :class:`GcodeAnalysisQueue` results from prior analysis, or ``None`` if there is none.
 	"""
 
 	def __str__(self):
@@ -341,6 +342,8 @@ class GcodeAnalysisQueue(AbstractAnalysisQueue):
 		import sys
 		import yaml
 
+		if self._current.analysis:
+			return self._current.analysis
 		try:
 			throttle = settings().getFloat(["gcodeAnalysis", "throttle_highprio"]) if high_priority \
 				else settings().getFloat(["gcodeAnalysis", "throttle_normalprio"])


### PR DESCRIPTION
The analysis from the Slicer or other sources is sent to the GCodeAnalyser, which can use it or ignore it.

This fixes https://github.com/foosel/OctoPrint/issues/2445#issuecomment-403599347

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

Run GCodeAnalyser on files sliced on RPi, in addition to those uploaded.

#### How was it tested? How can it be tested by the reviewer?

Without this patch:
1. Run OctoPrint
2. Upload a file.
3. Observe that the file is analyzed (logs will show `Starting analysis of <filename>`)
4. Slice a file using a built-in slicer, like cura.
5. *No logs about analyzing are printing.*

With this patch:
1. Run OctoPrint
2. Upload a file.
3. Observe that the file is analyzed (logs will show `Starting analysis of <filename>`)
4. Slice a file using a built-in slicer, like cura.
5. *Observe that the file is analyzed (logs will show `Starting analysis of <filename>`)*

#### Any background context you want to provide?

This is important for the new analysis hook.
https://github.com/foosel/OctoPrint/issues/2445#issuecomment-403599347

#### What are the relevant tickets if any?

https://github.com/foosel/OctoPrint/issues/2445