### PR TITLE
Faster gcode analysis: Remove kwargs Vector.__init__ and simplify getCodeFloat

### DIFF
--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -43,15 +43,9 @@ class Vector3D(object):
 	True
 	"""
 
-	def __init__(self, *args, **kwargs):
-		self.x = kwargs.get("x", 0.0)
-		self.y = kwargs.get("y", 0.0)
-		self.z = kwargs.get("z", 0.0)
-
+	def __init__(self, *args):
 		if len(args) == 3:
-			self.x = args[0]
-			self.y = args[1]
-			self.z = args[2]
+			(self.x, self.y, self.z) = args
 
 		elif len(args) == 1:
 			# copy constructor
@@ -504,9 +498,7 @@ def getCodeFloat(line, code):
 	m = line.find(' ', n)
 	try:
 		if m < 0:
-			val = float(line[n:])
-		else:
-			val = float(line[n:m])
-		return val if not (math.isnan(val) or math.isinf(val)) else None
+			return float(line[n:])
+		return float(line[n:m])
 	except:
 		return None


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?

Gcode analysis is very slow on RPi.  This PR improves performance by 10% by:

* Removing the kwargs constructions from Vector3D, because it is never used.
* Simplify the getFloatCode because it is called a lot.

#### How was it tested? How can it be tested by the reviewer?

Ran it on a large file and compared the time to run with this command:

`time python ./src/octoprint/cli/analysis.py --speed-x=6000 --speed-y=6000 --max-t=10 --throttle=0.0 --throttle-lines=100 BIG_GCODE_FILE.gco`

Tested the code like this:

`python -m doctest -v ./src/octoprint/util/gcodeInterpreter.py`

Profiled with this command:

`python -m cProfile -s tottime ./src/octoprint/cli/analysis.py --speed-x=6000 --speed-y=6000 --max-t=10 --throttle=0.0 --throttle-lines=100 BIG_GCODE_FILE.gco`