### PR TITLE
201809 py3 devel prep batch b

### DIFF
--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -11,6 +11,7 @@ __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agp
 
 import os
 import traceback
+import six
 import sys
 import re
 import tempfile
@@ -1641,10 +1642,10 @@ class CaseInsensitiveSet(collections.Set):
 	"""
 
 	def __init__(self, *args):
-		self.data = set([x.lower() if isinstance(x, (str, unicode)) else x for x in args])
+		self.data = set([x.lower() if isinstance(x, six.string_types) else x for x in args])
 
 	def __contains__(self, item):
-		if isinstance(item, (str, unicode)):
+		if isinstance(item, six.string_types):
 			return item.lower() in self.data
 		else:
 			return item in self.data

--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -11,7 +11,7 @@ __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agp
 
 import os
 import traceback
-import six
+import past.builtins
 import sys
 import re
 import tempfile
@@ -1642,10 +1642,10 @@ class CaseInsensitiveSet(collections.Set):
 	"""
 
 	def __init__(self, *args):
-		self.data = set([x.lower() if isinstance(x, six.string_types) else x for x in args])
+		self.data = set([x.lower() if isinstance(x, past.builtins.basestring) else x for x in args])
 
 	def __contains__(self, item):
-		if isinstance(item, six.string_types):
+		if isinstance(item, past.builtins.basestring):
 			return item.lower() in self.data
 		else:
 			return item in self.data

--- a/tests/filemanager/test_filemanager.py
+++ b/tests/filemanager/test_filemanager.py
@@ -301,7 +301,7 @@ class FileManagerTest(unittest.TestCase):
 		                pos=pos,
 		                date=now)
 
-		mock_yaml_safe_dump.assert_called_with(expected, stream=mock_atomic_write_handle, default_flow_style=False, indent="  ", allow_unicode=True)
+		mock_yaml_safe_dump.assert_called_with(expected, stream=mock_atomic_write_handle, default_flow_style=False, indent=2, allow_unicode=True)
 
 	@mock.patch("octoprint.util.atomic_write", create=True)
 	@mock.patch("yaml.safe_dump", create=True)

--- a/tests/filemanager/test_filemanager.py
+++ b/tests/filemanager/test_filemanager.py
@@ -9,11 +9,16 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 import io
 import unittest
 import mock
+import six
 
 import octoprint.filemanager
 import octoprint.filemanager.util
 
 import octoprint.settings
+
+# we can't seem to get this from six.moves, so we have to work around it to ensure py2/py3 compatability
+BUILTINS = "builtins"
+if six.PY2: BUILTINS = "__builtin__"
 
 class FilemanagerMethodTest(unittest.TestCase):
 
@@ -287,7 +292,7 @@ class FileManagerTest(unittest.TestCase):
 		mock_time.return_value = now
 		self.local_storage.path_in_storage.return_value = path
 
-		with mock.patch("builtins.open", mock.mock_open(), create=True) as m:
+		with mock.patch("{}.open".format(BUILTINS), mock.mock_open(), create=True) as m:
 			self.file_manager.save_recovery_data(octoprint.filemanager.FileDestinations.LOCAL, path, pos)
 			mock_atomic_write.assert_called_with(recovery_file, max_permissions=0o666)
 
@@ -312,7 +317,7 @@ class FileManagerTest(unittest.TestCase):
 
 		mock_yaml_safe_dump.side_effect = RuntimeError
 
-		with mock.patch("builtins.open", mock.mock_open(), create=True) as m:
+		with mock.patch("{}.open".format(BUILTINS), mock.mock_open(), create=True) as m:
 		  self.file_manager.save_recovery_data(octoprint.filemanager.FileDestinations.LOCAL, path, pos)
 
 	@mock.patch("os.path.isfile")
@@ -356,7 +361,7 @@ class FileManagerTest(unittest.TestCase):
 		            date=123456789)
 		text_data = yaml.dump(data)
 
-		with mock.patch("__builtin__.open", mock.mock_open(read_data=text_data)) as m:
+		with mock.patch("{}.open".format(BUILTINS), mock.mock_open(read_data=text_data)) as m:
 			# moved safe_load to here so we could mock up the return value properly
 			with mock.patch("yaml.safe_load", return_value=data) as n:
 				result = self.file_manager.get_recovery_data()

--- a/tests/filemanager/test_filemanager.py
+++ b/tests/filemanager/test_filemanager.py
@@ -53,18 +53,18 @@ class FilemanagerMethodTest(unittest.TestCase):
 		self.assertTrue("machinecode" in full)
 		self.assertTrue("gcode" in full["machinecode"])
 		self.assertTrue(isinstance(full["machinecode"]["gcode"], octoprint.filemanager.ContentTypeMapping))
-		self.assertItemsEqual(["gcode", "gco", "g"], full["machinecode"]["gcode"].extensions)
+		self.assertSetEqual(set(["gcode", "gco", "g"]), set(full["machinecode"]["gcode"].extensions))
 		self.assertTrue("foo" in full["machinecode"])
 		self.assertTrue(isinstance(full["machinecode"]["foo"], list))
-		self.assertItemsEqual(["f", "foo"], full["machinecode"]["foo"])
+		self.assertSetEqual(set(["f", "foo"]), set(full["machinecode"]["foo"]))
 
 		self.assertTrue("model" in full)
 		self.assertTrue("stl" in full["model"])
 		self.assertTrue(isinstance(full["model"]["stl"], octoprint.filemanager.ContentTypeMapping))
-		self.assertItemsEqual(["stl"], full["model"]["stl"].extensions)
+		self.assertSetEqual(set(["stl"]), set(full["model"]["stl"].extensions))
 		self.assertTrue("amf" in full["model"])
 		self.assertTrue(isinstance(full["model"]["amf"], list))
-		self.assertItemsEqual(["amf"], full["model"]["amf"])
+		self.assertSetEqual(set(["amf"]), set(full["model"]["amf"]))
 
 	def test_get_mimetype(self):
 		self.assertEqual(octoprint.filemanager.get_mime_type("foo.stl"), "application/sla")
@@ -235,22 +235,18 @@ class FileManagerTest(unittest.TestCase):
 	def test_add_folder_not_ignoring_existing(self):
 		self.local_storage.add_folder.side_effect = RuntimeError("already there")
 
-		try:
+		with self.assertRaises(RuntimeError, msg="already there"):
 			self.file_manager.add_folder(octoprint.filemanager.FileDestinations.LOCAL, "test_folder", ignore_existing=False)
 			self.fail("Expected an exception to occur!")
-		except RuntimeError as e:
-			self.assertEqual("already there", e.message)
 		self.local_storage.add_folder.assert_called_once_with("test_folder", ignore_existing=False, display=None)
 
 	def test_add_folder_display(self):
 		self.local_storage.add_folder.side_effect = RuntimeError("already there")
 
-		try:
+		with self.assertRaises(RuntimeError, msg="already there"):
 			self.file_manager.add_folder(octoprint.filemanager.FileDestinations.LOCAL, "test_folder",
 			                             display=u"täst_folder")
 			self.fail("Expected an exception to occur!")
-		except RuntimeError as e:
-			self.assertEqual("already there", e.message)
 		self.local_storage.add_folder.assert_called_once_with("test_folder",
 		                                                      ignore_existing=True,
 		                                                      display=u"täst_folder")
@@ -287,41 +283,37 @@ class FileManagerTest(unittest.TestCase):
 		pos = 1234
 		recovery_file = os.path.join("/path/to/a/base_folder", "print_recovery_data.yaml")
 
-		mock_atomic_write.return_value = mock.MagicMock(spec=file)
 		mock_atomic_write_handle = mock_atomic_write.return_value.__enter__.return_value
 		mock_time.return_value = now
 		self.local_storage.path_in_storage.return_value = path
 
-		self.file_manager.save_recovery_data(octoprint.filemanager.FileDestinations.LOCAL, path, pos)
+		with mock.patch("builtins.open", mock.mock_open(), create=True) as m:
+			self.file_manager.save_recovery_data(octoprint.filemanager.FileDestinations.LOCAL, path, pos)
+			mock_atomic_write.assert_called_with(recovery_file, max_permissions=0o666)
 
 		expected = dict(origin=octoprint.filemanager.FileDestinations.LOCAL,
 		                path=path,
 		                pos=pos,
 		                date=now)
 
-
-		mock_atomic_write.assert_called_with(recovery_file)
 		mock_yaml_safe_dump.assert_called_with(expected, stream=mock_atomic_write_handle, default_flow_style=False, indent="  ", allow_unicode=True)
 
 	@mock.patch("octoprint.util.atomic_write", create=True)
 	@mock.patch("yaml.safe_dump", create=True)
 	@mock.patch("time.time")
-	def test_save_recovery_data(self, mock_time, mock_yaml_safe_dump, mock_atomic_write):
+	def test_save_recovery_data_with_error(self, mock_time, mock_yaml_safe_dump, mock_atomic_write):
 		import os
 
-		now = 123456789
 		path = "some_file.gco"
 		pos = 1234
 		recovery_file = os.path.join("/path/to/a/base_folder", "print_recovery_data.yaml")
 
-		mock_atomic_write.return_value = mock.MagicMock(spec=file)
-		mock_atomic_write_handle = mock_atomic_write.return_value.__enter__.return_value
-		mock_time.return_value = now
 		self.local_storage.path_in_storage.return_value = path
 
 		mock_yaml_safe_dump.side_effect = RuntimeError
 
-		self.file_manager.save_recovery_data(octoprint.filemanager.FileDestinations.LOCAL, path, pos)
+		with mock.patch("builtins.open", mock.mock_open(), create=True) as m:
+		  self.file_manager.save_recovery_data(octoprint.filemanager.FileDestinations.LOCAL, path, pos)
 
 	@mock.patch("os.path.isfile")
 	@mock.patch("os.remove")
@@ -352,29 +344,26 @@ class FileManagerTest(unittest.TestCase):
 
 		self.file_manager.delete_recovery_data()
 
-	@mock.patch("os.path.isfile")
-	@mock.patch("yaml.safe_load")
-	def test_get_recovery_data(self, mock_yaml_safe_load, mock_isfile):
+	@mock.patch("os.path.isfile", return_value=True)
+	def test_get_recovery_data(self, mock_isfile):
 		import os
+		import yaml
 		recovery_file = os.path.join("/path/to/a/base_folder", "print_recovery_data.yaml")
-
-		mock_isfile.return_value = True
 
 		data = dict(path="some_path.gco",
 		            origin="local",
 		            pos=1234,
 		            date=123456789)
-		mock_yaml_safe_load.return_value = data
+		text_data = yaml.dump(data)
 
-		with mock.patch("__builtin__.open", mock.mock_open(read_data=data), create=True) as m:
-			result = self.file_manager.get_recovery_data()
+		with mock.patch("__builtin__.open", mock.mock_open(read_data=text_data)) as m:
+			# moved safe_load to here so we could mock up the return value properly
+			with mock.patch("yaml.safe_load", return_value=data) as n:
+				result = self.file_manager.get_recovery_data()
 
-			self.assertDictEqual(data, result)
-
-			m.assert_called_with(recovery_file)
-
-			mock_handle = m()
-			mock_yaml_safe_load.assert_called_with(mock_handle)
+				self.assertDictEqual(data, result)
+				n.assert_called_with(m())
+				mock_isfile.assert_called_with(recovery_file)
 
 	@mock.patch("os.path.isfile")
 	def test_get_recovery_data_no_file(self, mock_isfile):

--- a/tests/server/util/test_flask.py
+++ b/tests/server/util/test_flask.py
@@ -487,15 +487,15 @@ class ReverseProxiedEnvironmentTest(unittest.TestCase):
 
 	def test_header_config_ok(self):
 		result = ReverseProxiedEnvironment.to_header_candidates(["prefix-header1", "prefix-header2"])
-		self.assertEquals(result, ["HTTP_PREFIX_HEADER1", "HTTP_PREFIX_HEADER2"])
+		self.assertEqual(result, ["HTTP_PREFIX_HEADER1", "HTTP_PREFIX_HEADER2"])
 
 	def test_header_config_string(self):
 		result = ReverseProxiedEnvironment.to_header_candidates("prefix-header")
-		self.assertEquals(result, ["HTTP_PREFIX_HEADER"])
+		self.assertEqual(result, ["HTTP_PREFIX_HEADER"])
 
 	def test_header_config_none(self):
 		result = ReverseProxiedEnvironment.to_header_candidates(None)
-		self.assertEquals(result, [])
+		self.assertEqual(result, [])
 
 ##~~
 
@@ -521,22 +521,22 @@ class OctoPrintFlaskRequestTest(unittest.TestCase):
 
 	def test_server_name(self):
 		request = OctoPrintFlaskRequest(standard_environ)
-		self.assertEquals("localhost", request.server_name)
+		self.assertEqual("localhost", request.server_name)
 
 	def test_server_port(self):
 		request = OctoPrintFlaskRequest(standard_environ)
-		self.assertEquals("5000", request.server_port)
+		self.assertEqual("5000", request.server_port)
 
 	def test_cookie_suffix(self):
 		request = OctoPrintFlaskRequest(standard_environ)
-		self.assertEquals("_P5000", request.cookie_suffix)
+		self.assertEqual("_P5000", request.cookie_suffix)
 	
 	def test_cookie_suffix_with_root(self):
 		script_root_environ = dict(standard_environ)
 		script_root_environ["SCRIPT_NAME"] = "/path/to/octoprint"
 		
 		request = OctoPrintFlaskRequest(script_root_environ)
-		self.assertEquals("_P5000_R|path|to|octoprint", request.cookie_suffix)
+		self.assertEqual("_P5000_R|path|to|octoprint", request.cookie_suffix)
 
 	def test_cookies(self):
 		environ = dict(standard_environ)

--- a/tests/server/util/test_flask.py
+++ b/tests/server/util/test_flask.py
@@ -487,11 +487,11 @@ class ReverseProxiedEnvironmentTest(unittest.TestCase):
 
 	def test_header_config_ok(self):
 		result = ReverseProxiedEnvironment.to_header_candidates(["prefix-header1", "prefix-header2"])
-		self.assertEqual(result, ["HTTP_PREFIX_HEADER1", "HTTP_PREFIX_HEADER2"])
+		self.assertSetEqual(set(result), set(["HTTP_PREFIX_HEADER1", "HTTP_PREFIX_HEADER2"]))
 
 	def test_header_config_string(self):
 		result = ReverseProxiedEnvironment.to_header_candidates("prefix-header")
-		self.assertEqual(result, ["HTTP_PREFIX_HEADER"])
+		self.assertSetEqual(set(result), set(["HTTP_PREFIX_HEADER"]))
 
 	def test_header_config_none(self):
 		result = ReverseProxiedEnvironment.to_header_candidates(None)

--- a/tests/timelapse/test_timelapse_renderjob.py
+++ b/tests/timelapse/test_timelapse_renderjob.py
@@ -33,7 +33,7 @@ class TimelapseRenderJobTest(unittest.TestCase):
 	@unpack
 	def test_create_ffmpeg_command_string(self, args, kwargs, expected):
 		actual = TimelapseRenderJob._create_ffmpeg_command_string(*args, **kwargs)
-		self.assertEquals(actual, expected)
+		self.assertEqual(actual, expected)
 
 	@data(
 		(dict(),
@@ -67,4 +67,4 @@ class TimelapseRenderJobTest(unittest.TestCase):
 	@unpack
 	def test_create_filter_string(self, kwargs, expected):
 		actual = TimelapseRenderJob._create_filter_string(**kwargs)
-		self.assertEquals(actual, expected)
+		self.assertEqual(actual, expected)

--- a/tests/util/test_caseinsensitive_set.py
+++ b/tests/util/test_caseinsensitive_set.py
@@ -18,8 +18,8 @@ class TestCaseInsensitiveSet(unittest.TestCase):
 
 	@ddt.data("A", "a", "foo", True, 23)
 	def test_contained(self, value):
-		self.assertTrue(value in self.set)
+		self.assertIn(value, self.set)
 
 	@ddt.data("b", "fnord", False, 42)
 	def test_not_contained(self, value):
-		self.assertFalse(value in self.set)
+		self.assertNotIn(value, self.set)

--- a/tests/util/test_pip.py
+++ b/tests/util/test_pip.py
@@ -77,4 +77,4 @@ class PipCallerTest(unittest.TestCase):
 		with mock.patch.object(site, "ENABLE_USER_SITE", user_site):
 			parsed = pkg_resources.parse_version(version)
 			actual = octoprint.util.pip.PipCaller.clean_install_command(args, parsed, virtual_env, use_user, force_user)
-		self.assertEquals(expected, actual)
+		self.assertEqual(expected, actual)


### PR DESCRIPTION
Work towards python3 compatability, focusing on tests. The following tests and related code are now compatible with both py2 and py3.

- tests/util/test_caseinsensitive_set.py
- tests/util/test_pip.py
- tests/timelapse/test_timelapse_renderjob.py
- tests/server/util/test_flask.py
- tests/filemanager/test_filemanager.py