### PR TITLE
Py3: get rid of unicode type reference

### DIFF
--- a/docs/features/accesscontrol.rst
+++ b/docs/features/accesscontrol.rst
@@ -31,7 +31,13 @@ Internet!).
 .. hint::
 
    If you plan to have your OctoPrint instance accessible over the internet,
-   **always enable Access Control**.
+   **always enable Access Control** and ideally **don't make it accessible to
+   everyone over the internet but instead use a VPN** or at the very least
+   HTTP basic authentication on a layer above OctoPrint.
+
+   A physical device that includes heaters and stepper motors really should not be
+   publicly reachable by everyone with an internet connection, even with access
+   control enabled.
 
 .. _sec-features-access_control-rerunning_wizard:
 

--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -447,7 +447,7 @@ class FileManager(object):
 	def list_files(self, destinations=None, path=None, filter=None, recursive=None):
 		if not destinations:
 			destinations = self._storage_managers.keys()
-		if isinstance(destinations, (str, unicode, basestring)):
+		if isinstance(destinations, basestring):
 			destinations = [destinations]
 
 		result = dict()

--- a/src/octoprint/filemanager/storage.py
+++ b/src/octoprint/filemanager/storage.py
@@ -1033,7 +1033,7 @@ class LocalFileStorage(StorageInterface):
 	def path_in_storage(self, path):
 		if isinstance(path, (tuple, list)):
 			path = self.join_path(*path)
-		if isinstance(path, (str, unicode, basestring)):
+		if isinstance(path, basestring):
 			path = to_unicode(path)
 			if path.startswith(self.basefolder):
 				path = path[len(self.basefolder):]

--- a/src/octoprint/logging/__init__.py
+++ b/src/octoprint/logging/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from octoprint.logging import handlers
+from past.builtins import basestring
 
 def log_to_handler(logger, handler, level, msg, exc_info=None, extra=None, *args):
 	"""
@@ -120,7 +121,7 @@ def get_divider_line(c, message=None, length=78, indent=3):
 		formatted divider line
 	"""
 
-	assert isinstance(c, (str, unicode, bytes)), "c is not text"
+	assert isinstance(c, (basestring, bytes)), "c is not text"
 	assert len(c) == 1, "c is not a single character"
 	assert isinstance(length, int), "length is not an int"
 	assert isinstance(indent, int), "indent is not an int"
@@ -128,7 +129,7 @@ def get_divider_line(c, message=None, length=78, indent=3):
 	if message is None:
 		return c * length
 
-	assert isinstance(message, (str, unicode, bytes)), "message is not text"
+	assert isinstance(message, (basestring, bytes)), "message is not text"
 
 	space = length - 2 * (indent + 1)
 	if space >= len(message):
@@ -147,4 +148,3 @@ def prefix_multilines(text, prefix=": "):
 
 	return lines[0] + "\n" + "\n".join(map(lambda line: prefix + line,
 	                                       lines[1:]))
-

--- a/src/octoprint/plugins/cura/profile.py
+++ b/src/octoprint/plugins/cura/profile.py
@@ -650,7 +650,7 @@ class Profile(object):
 		if value is None:
 			return default
 
-		if isinstance(value, (str, unicode, basestring)):
+		if isinstance(value, basestring):
 			value = value.replace(",", ".").strip()
 
 		try:
@@ -665,7 +665,7 @@ class Profile(object):
 
 		if isinstance(value, bool):
 			return value
-		elif isinstance(value, (str, unicode, basestring)):
+		elif isinstance(value, basestring):
 			return value.lower() == "true" or value.lower() == "yes" or value.lower() == "on" or value == "1"
 		elif isinstance(value, (int, float)):
 			return value > 0
@@ -702,7 +702,7 @@ class Profile(object):
 
 		result = []
 		for k, v in profile.items():
-			if isinstance(v, (str, unicode)):
+			if isinstance(v, basestring):
 				result.append("{k}={v}".format(k=k, v=v.encode("utf-8")))
 			else:
 				result.append("{k}={v}".format(k=k, v=v))
@@ -754,7 +754,7 @@ class Profile(object):
 		else:
 			contents = self.get_gcode_template(key, extruder_count=extruder_count)
 
-		return unicode(prefix + re.sub("(.)\{([^\}]*)\}", self.replaceTagMatch, contents).rstrip() + '\n' + postfix).strip().encode('utf-8') + '\n'
+		return u'{}'.format(prefix + re.sub("(.)\{([^\}]*)\}", self.replaceTagMatch, contents).rstrip() + '\n' + postfix).strip().encode('utf-8') + '\n'
 
 	def get_start_gcode_prefix(self, contents):
 		extruder_count = self.get_int("extruder_amount")

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -354,7 +354,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
 	def home(self, axes, *args, **kwargs):
 		if not isinstance(axes, (list, tuple)):
-			if isinstance(axes, (str, unicode)):
+			if isinstance(axes, basestring):
 				axes = [axes]
 			else:
 				raise ValueError("axes is neither a list nor a string: {axes}".format(axes=axes))

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -1814,7 +1814,7 @@ class LifecycleManager(object):
 			lifecycle_callback(name, plugin)
 
 	def add_callback(self, events, callback):
-		if isinstance(events, (str, unicode)):
+		if isinstance(events, basestring):
 			events = [events]
 
 		for event in events:
@@ -1826,7 +1826,7 @@ class LifecycleManager(object):
 				if callback in self._plugin_lifecycle_callbacks[event]:
 					self._plugin_lifecycle_callbacks[event].remove(callback)
 		else:
-			if isinstance(events, (str, unicode)):
+			if isinstance(events, basestring):
 				events = [events]
 
 			for event in events:

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -9,6 +9,7 @@ import logging
 import os
 import mimetypes
 import re
+from past.builtins import basestring
 
 import tornado
 import tornado.web
@@ -23,8 +24,6 @@ import tornado.tcpserver
 import tornado.util
 
 import octoprint.util
-
-
 
 def fix_json_encode():
 	"""
@@ -621,7 +620,7 @@ class WsgiInputContainer(object):
 
 		# determine the request_body to supply as wsgi.input
 		if body is not None:
-			if isinstance(body, (bytes, str, unicode)):
+			if isinstance(body, (bytes, basestring)):
 				request_body = io.BytesIO(tornado.escape.utf8(body))
 			else:
 				request_body = body

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -1497,7 +1497,7 @@ class Settings(object):
 			return value
 		if isinstance(value, (int, float)):
 			return value != 0
-		if isinstance(value, (str, unicode)):
+		if isinstance(value, basestring):
 			return value.lower() in valid_boolean_trues
 		return value is not None
 

--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -25,6 +25,8 @@ import collections
 import frozendict
 import copy
 
+PY3 = sys.version_info[0] == 3
+
 try:
 	import queue
 except ImportError:
@@ -111,7 +113,7 @@ variable_deprecated = warning_factory(DeprecationWarning)
 """
 A function for deprecated variables. Logs a deprecation warning via Python's `:mod:`warnings` module including the
 supplied ``message``. The call stack level used (for adding the source location of the offending call to the
-warning) can be overridden using the optional ``stacklevel`` parameter. 
+warning) can be overridden using the optional ``stacklevel`` parameter.
 
 Arguments:
     message (string): The message to include in the deprecation warning.
@@ -502,6 +504,10 @@ def filter_non_ascii(line):
 
 def to_str(s_or_u, encoding="utf-8", errors="strict"):
 	"""Make sure ``s_or_u`` is a str."""
+	if PY3:
+		if isinstance(s_or_u, bytes):
+			return s_or_u.decode(encoding)
+		return s_or_u
 	if isinstance(s_or_u, unicode):
 		return s_or_u.encode(encoding, errors=errors)
 	else:
@@ -510,6 +516,8 @@ def to_str(s_or_u, encoding="utf-8", errors="strict"):
 
 def to_unicode(s_or_u, encoding="utf-8", errors="strict"):
 	"""Make sure ``s_or_u`` is a unicode string."""
+	if PY3:
+		return s_or_u
 	if isinstance(s_or_u, str):
 		return s_or_u.decode(encoding, errors=errors)
 	else:

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -12,6 +12,9 @@ import re
 import threading
 import contextlib
 import copy
+import sys
+
+PY3 = sys.version_info[0] == 3
 
 try:
 	import queue
@@ -949,10 +952,14 @@ class MachineCom(object):
 					continue
 
 				def to_list(data):
-					if isinstance(data, str):
-						data = map(str.strip, data.split("\n"))
-					elif isinstance(data, unicode):
-						data = map(unicode.strip, data.split("\n"))
+					if PY3:
+						if isinstance(data, str):
+							data = map(str.strip, data.split("\n"))
+					else:
+						if isinstance(data, str):
+							data = map(str.strip, data.split("\n"))
+						elif isinstance(data, unicode):
+							data = map(unicode.strip, data.split("\n"))
 
 					if isinstance(data, (list, tuple)):
 						return list(data)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Prepare Python 3 migration by removing all references to unicode python2 string type

#### How was it tested? How can it be tested by the reviewer?
Tests run fine

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
