### PR TITLE
Remove requirement to have messages.pot before using babel_* commands

### DIFF
--- a/docs/features/accesscontrol.rst
+++ b/docs/features/accesscontrol.rst
@@ -31,7 +31,13 @@ Internet!).
 .. hint::
 
    If you plan to have your OctoPrint instance accessible over the internet,
-   **always enable Access Control**.
+   **always enable Access Control** and ideally **don't make it accessible to
+   everyone over the internet but instead use a VPN** or at the very least
+   HTTP basic authentication on a layer above OctoPrint.
+
+   A physical device that includes heaters and stepper motors really should not be
+   publicly reachable by everyone with an internet connection, even with access
+   control enabled.
 
 .. _sec-features-access_control-rerunning_wizard:
 

--- a/src/octoprint_setuptools/__init__.py
+++ b/src/octoprint_setuptools/__init__.py
@@ -524,8 +524,7 @@ def create_plugin_setup_parameters(identifier="todo", name="TODO", version="0.1"
 	translation_dir = os.path.join(source_folder, "translations")
 	pot_file = os.path.join(translation_dir, "messages.pot")
 	bundled_dir = os.path.join(source_folder, package, "translations")
-	if os.path.isdir(translation_dir) and os.path.isfile(pot_file):
-		cmdclass.update(get_babel_commandclasses(pot_file=pot_file, output_dir=translation_dir, bundled_dir=bundled_dir, pack_name_prefix="{name}-i18n-".format(**locals()), pack_path_prefix="_plugins/{identifier}/".format(**locals())))
+	cmdclass.update(get_babel_commandclasses(pot_file=pot_file, output_dir=translation_dir, bundled_dir=bundled_dir, pack_name_prefix="{name}-i18n-".format(**locals()), pack_path_prefix="_plugins/{identifier}/".format(**locals())))
 
 	from setuptools import find_packages
 	packages = list(set([package] + filter(lambda x: x.startswith("{package}.".format(package=package)), find_packages(where=source_folder, exclude=ignored_packages)) + additional_packages))


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [ ] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [ ] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
Fixes #2844 

#### How was it tested? How can it be tested by the reviewer?

I deleted the line and then tried to create a plugin and extract translations.  The inputs and outputs before the change:

```
└──> octoprint dev plugin:new Test
plugin_package [octoprint_Test]: 
plugin_name [OctoPrint-Test]: 
repo_name [OctoPrint-Test]: 
full_name [You]: 
email [you@example.com]: 
github_username [you]: 
plugin_version [0.1.0]: 
plugin_description [TODO]: 
plugin_license [AGPLv3]: 
plugin_homepage [https://github.com/you/OctoPrint-Test]: 
plugin_source [https://github.com/you/OctoPrint-Test]: 
plugin_installurl [https://github.com/you/OctoPrint-Test/archive/master.zip]: 
└──> cd OctoPrint-Test 
└──> python setup.py babel_extract
Found packages: ['octoprint_Test']
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'babel_extract'
```

After the change:

```
└──> octoprint dev plugin:new Test
plugin_package [octoprint_Test]: 
plugin_name [OctoPrint-Test]: 
repo_name [OctoPrint-Test]: 
full_name [You]: 
email [you@example.com]: 
github_username [you]: 
plugin_version [0.1.0]: 
plugin_description [TODO]: 
plugin_license [AGPLv3]: 
plugin_homepage [https://github.com/you/OctoPrint-Test]: 
plugin_source [https://github.com/you/OctoPrint-Test]: 
plugin_installurl [https://github.com/you/OctoPrint-Test/archive/master.zip]: 
└──> cd OctoPrint-Test 
└──> python setup.py babel_extract
Found packages: ['octoprint_Test']
running babel_extract
extracting messages from octoprint_Test/__init__.py
extracting messages from octoprint_Test/static/js/Test.js (extract_messages="gettext, ngettext")
writing PO template file to ./translations/messages.pot
```
