### PR TITLE
Fixed unsafe write_message call from another thread

### DIFF
--- a/src/octoprint/vendor/sockjs/tornado/transports/websocket.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/websocket.py
@@ -11,6 +11,7 @@ import socket
 from octoprint.vendor.sockjs.tornado import proto, websocket
 from octoprint.vendor.sockjs.tornado.transports import base
 from octoprint.vendor.sockjs.tornado.util import bytes_to_str
+from tornado.ioloop import IOLoop
 
 LOG = logging.getLogger("tornado.general")
 
@@ -81,11 +82,16 @@ class WebSocketTransport(websocket.SockJSWebSocketHandler, base.BaseTransportMix
             session.close()
 
     def send_pack(self, message, binary=False):
-        # Send message
-        try:
-            self.write_message(message, binary)
-        except IOError:
-            self.server.io_loop.add_callback(self.on_close)
+		if IOLoop.current(False) == self.server.io_loop:
+			# Running in Main Thread
+			# Send message
+			try:
+				self.write_message(message, binary)
+			except IOError:
+				self.server.io_loop.add_callback(self.on_close)
+		else:
+			# Not running in Main Thread so use proper thread to send message
+			self.server.io_loop.add_callback(lambda: self.send_pack(message, binary))
 
     def session_closed(self):
         # If session was closed by the application, terminate websocket


### PR DESCRIPTION
PR regarding issue #2850

#### What does this PR do and why is it necessary?

Problem described in https://github.com/foosel/OctoPrint/issues/2850

#### How was it tested? How can it be tested by the reviewer?

I haven't tested it in maintenance branch. Fix was initially coded against master and was deployed to OctoPi 1.3.9 instance for testing. Also tested against local server that runs with PyCharm. Tested the fix for over a week and the problem is gone.

#### Any background context you want to provide?

Problem described in https://github.com/foosel/OctoPrint/issues/2850

#### What are the relevant tickets if any?

https://github.com/foosel/OctoPrint/issues/2850

#### Screenshots (if appropriate)

N/A

#### Further notes

Cloned repo and checked out maintenance branch and for some reason the virtual printer appears as connected and cannot disconnect it or make it work. This is why I was not able to test the fix in maintenance branch. Modified code looks the same in master and maintenance so fix should still work fine.

Once merged, I'm happy to give it another test.

PS: I did not add myself to the AUTHORS.md file. 
