### PR TITLE
Documentation fixed and extrusion speed value check

### DIFF
--- a/docs/api/printer.rst
+++ b/docs/api/printer.rst
@@ -219,7 +219,7 @@ Issue a print head command
        axes values are relative amounts) or to absolute position (provided axes values are coordinates)
      * ``speed``: Optional. Speed at which to move. If not provided, minimum speed for all selected axes from printer
        profile will be used. If provided but ``false``, no speed parameter will be appended to the command. Otherwise
-       interpreted as an integer signifying the speed in mm/s, to append to the command.
+       interpreted as an integer signifying the speed in mm/min, to append to the command.
 
    home
      Homes the print head in all of the given axes. Additional parameters are:

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -369,10 +369,14 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
 		# Use specified speed (if any)
 		extrusion_speed = speed
+		max_e_speed = printer_profile["axes"]["e"]["speed"]
 
 		if speed is None:
 			# No speed was specified so default to value configured in printer profile
-			extrusion_speed = printer_profile["axes"]["e"]["speed"]
+			extrusion_speed = max_e_speed
+		else:
+			# Make sure that specified value is not greater than maximum as defined in printer profile
+			extrusion_speed = min([speed, max_e_speed])
 
 		self.commands(["G91", "G1 E%s F%d" % (amount, extrusion_speed), "G90"],
 		              tags=kwargs.get("tags", set()) | {"trigger:printer.extrude"})

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -368,7 +368,6 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 		printer_profile = self._printerProfileManager.get_current_or_default()
 
 		# Use specified speed (if any)
-		extrusion_speed = speed
 		max_e_speed = printer_profile["axes"]["e"]["speed"]
 
 		if speed is None:


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

1. Fixed documentation about speed unit (mm/sec -> mm/min)
1. Extrusion speed is now limited to printer profile max value 

#### How was it tested? How can it be tested by the reviewer?

Manually tested using HTTP client

#### Any background context you want to provide?

This is a follow up for https://github.com/foosel/OctoPrint/pull/2865

#### What are the relevant tickets if any?

Nope

#### Screenshots (if appropriate)

Nope

#### Further notes

Nope