### PR TITLE
Close orphaned request_access dialogs

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -93,6 +93,7 @@ date of first contribution):
   * [Andy Castille](https://github.com/klikini)
   * [Gaston Dombiak](https://github.com/gdombiak)
   * [Brad Fisher](https://github.com/bradcfisher)
+  * [Aldo Hoeben](https://github.com/fieldofview)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/plugins/appkeys/__init__.py
+++ b/src/octoprint/plugins/appkeys/__init__.py
@@ -15,23 +15,25 @@ import octoprint.plugin
 from octoprint.settings import valid_boolean_trues
 from octoprint.server.util.flask import restricted_access, no_firstrun_access
 from octoprint.server import NO_CONTENT, current_user, admin_permission
-from octoprint.util import atomic_write, monotonic_time
+from octoprint.util import atomic_write, monotonic_time, ResettableTimer
 
 
 CUTOFF_TIME = 10 * 60 # 10min
-
+POLL_TIMEOUT = 5 # 5 seconds
 
 class AppAlreadyExists(Exception):
 	pass
 
 
 class PendingDecision(object):
-	def __init__(self, app_id, app_token, user_id, user_token):
+	def __init__(self, appkeys_plugin, app_id, app_token, user_id, user_token):
 		self.app_id = app_id
 		self.app_token = app_token
 		self.user_id = user_id
 		self.user_token = user_token
 		self.created = monotonic_time()
+		self.poll_timeout = ResettableTimer(POLL_TIMEOUT, appkeys_plugin.expire_request, [user_token])
+		self.poll_timeout.start()
 
 	def external(self):
 		return dict(app_id=self.app_id,
@@ -91,6 +93,17 @@ class AppKeysPlugin(octoprint.plugin.AssetPlugin,
 		self._key_path = os.path.join(self.get_plugin_data_folder(), "keys.yaml")
 		self._load_keys()
 
+	def expire_request(self, user_token):
+		len_before = len(self._pending_decisions)
+		self._pending_decisions = filter(lambda x: x.user_token != user_token, self._pending_decisions)
+		len_after = len(self._pending_decisions)
+
+		if len_after < len_before:
+			self._plugin_manager.send_plugin_message(self._identifier, dict(
+				type="end_request",
+				user_token=user_token
+			))
+
 	##~~ TemplatePlugin
 
 	def get_template_configs(self):
@@ -133,7 +146,11 @@ class AppKeysPlugin(octoprint.plugin.AssetPlugin,
 	@octoprint.plugin.BlueprintPlugin.route("/request/<app_token>")
 	@no_firstrun_access
 	def handle_decision_poll(self, app_token):
-		if self._is_pending(app_token):
+		result = self._get_pending_by_app_token(app_token)
+		if result:
+			for pending_decision in result:
+				pending_decision.poll_timeout.reset()
+
 			response = flask.jsonify(message="Awaiting decision")
 			response.status_code = 202
 			return response
@@ -185,7 +202,7 @@ class AppKeysPlugin(octoprint.plugin.AssetPlugin,
 			keys = self._api_keys_for_user(user_id)
 
 		return flask.jsonify(keys=map(lambda x: x.external(), keys),
-		                     pending=dict((x.user_token, x.external()) for x in self._get_pending(user_id)))
+		                     pending=dict((x.user_token, x.external()) for x in self._get_pending_by_user_id(user_id)))
 
 	def on_api_command(self, command, data):
 		user_id = current_user.get_name()
@@ -227,20 +244,20 @@ class AppKeysPlugin(octoprint.plugin.AssetPlugin,
 
 		with self._pending_lock:
 			self._remove_stale_pending()
-			self._pending_decisions.append(PendingDecision(app_name, app_token, user_id, user_token))
+			self._pending_decisions.append(PendingDecision(self, app_name, app_token, user_id, user_token))
 
 		return app_token, user_token
 
-	def _is_pending(self, app_token):
+	def _get_pending_by_app_token(self, app_token):
+		result = []
 		with self._pending_lock:
 			self._remove_stale_pending()
 			for data in self._pending_decisions:
 				if data.app_token == app_token:
-					return True
+					result.append(data)
+		return result
 
-		return False
-
-	def _get_pending(self, user_id):
+	def _get_pending_by_user_id(self, user_id):
 		result = []
 		with self._pending_lock:
 			self._remove_stale_pending()

--- a/src/octoprint/plugins/appkeys/__init__.py
+++ b/src/octoprint/plugins/appkeys/__init__.py
@@ -157,6 +157,12 @@ class AppKeysPlugin(octoprint.plugin.AssetPlugin,
 		if not result:
 			return flask.abort(404)
 
+		# Close access_request dialog for this request on all open OctoPrint connections
+		self._plugin_manager.send_plugin_message(self._identifier, dict(
+			type="end_request",
+			user_token=user_token
+		))
+
 		return NO_CONTENT
 
 	def is_blueprint_protected(self):


### PR DESCRIPTION
Checklist checked.

~This PR is a work in progress, and as such preliminary, but I wanted to let you know I am working on it and am planning to have this working today.~

#### What does this PR do and why is it necessary?
This PR makes a couple of enhancements to the appkey plugin, regarding the dialogs that are opened when an appkey access request is made
  * [DONE] Close request_access dialogs on other open connections when a decision is made;
   Once a decision is made on one connection (browser window), dialogs on other connections are no longer relevant.
  * [DONE] Close request_access dialogs after a timeout if the client that initiated the request stops polling

#### How was it tested? How can it be tested by the reviewer?
* Open multiple browser windows to an OctoPrint instance
* Start an appkey request
* Make a decision in one of the browser windows

#### Any background context you want to provide?
As discussed here: https://discourse.octoprint.org/t/appkeys-feedback/4958/2

#### What are the relevant tickets if any?
n/a

#### Screenshots (if appropriate)
none

#### Further notes
none