### PR TITLE
add throttle_state to tracking

### DIFF
--- a/src/octoprint/plugins/pi_support/__init__.py
+++ b/src/octoprint/plugins/pi_support/__init__.py
@@ -244,8 +244,12 @@ class PiSupportPlugin(octoprint.plugin.EnvironmentDetectionPlugin,
 	def _check_throttled_state_condition(self):
 		return self._throttle_functional
 
-	def get_throttle_state(self, run_now=False):
-		'''public method to pass around in plugin_helpers'''
+	def get_throttle_state(self, raw_value_only=False, run_now=False):
+		'''public method to pass around in plugin_helpers.'''
+
+		# Not using the `run_now` yet, but leaving it as a placeholder.
+
+		if raw_value_only: return self._throttle_state._raw_value
 		return self._throttle_state.as_dict()
 
 	def _check_throttled_state(self):

--- a/src/octoprint/plugins/pi_support/__init__.py
+++ b/src/octoprint/plugins/pi_support/__init__.py
@@ -35,10 +35,9 @@ _FLAG_PAST_UNDERVOLTAGE = 1 << 16
 _FLAG_PAST_FREQ_CAPPED = 1 << 17
 _FLAG_PAST_THROTTLED = 1 << 18
 
-
 class ThrottleState(object):
 	@classmethod
-	def from_value(cls, value):
+	def from_value(cls, value=0):
 		if value == 0:
 			return ThrottleState()
 
@@ -47,10 +46,12 @@ class ThrottleState(object):
 		              throttled=_FLAG_THROTTLED & value == _FLAG_THROTTLED,
 		              past_undervoltage=_FLAG_PAST_UNDERVOLTAGE & value == _FLAG_PAST_UNDERVOLTAGE,
 		              past_freq_capped=_FLAG_PAST_FREQ_CAPPED & value == _FLAG_PAST_FREQ_CAPPED,
-		              past_throttled=_FLAG_PAST_THROTTLED & value == _FLAG_PAST_THROTTLED)
+		              past_throttled=_FLAG_PAST_THROTTLED & value == _FLAG_PAST_THROTTLED,
+		              raw_value=value)
 		return ThrottleState(**kwargs)
 
 	def __init__(self, **kwargs):
+		self._raw_value = kwargs.get('raw_value', -1)
 		self._undervoltage = False
 		self._freq_capped = False
 		self._throttled = False
@@ -111,7 +112,8 @@ class ThrottleState(object):
 		       and self._past_throttled == other._past_throttled
 
 	def as_dict(self):
-		return dict(current_undervoltage=self.current_undervoltage,
+		return dict(raw_value=self._raw_value,
+		            current_undervoltage=self.current_undervoltage,
 		            past_undervoltage=self.past_undervoltage,
 		            current_overheat=self.current_overheat,
 		            past_overheat=self.past_overheat,
@@ -242,6 +244,10 @@ class PiSupportPlugin(octoprint.plugin.EnvironmentDetectionPlugin,
 	def _check_throttled_state_condition(self):
 		return self._throttle_functional
 
+	def get_throttle_state(self, run_now=False):
+		'''public method to pass around in plugin_helpers'''
+		return self._throttle_state.as_dict()
+
 	def _check_throttled_state(self):
 		command = self._settings.get(["vcgencmd_throttle_check_command"])
 
@@ -299,5 +305,11 @@ def __plugin_check__():
 	return "raspberry pi" in proc_dt_model.lower()
 
 def __plugin_load__():
+	plugin = PiSupportPlugin()
 	global __plugin_implementation__
-	__plugin_implementation__ = PiSupportPlugin()
+	__plugin_implementation__ = plugin
+
+	global __plugin_helpers__
+	__plugin_helpers__ = dict(
+		get_throttled=plugin.get_throttle_state
+	)

--- a/src/octoprint/plugins/tracking/__init__.py
+++ b/src/octoprint/plugins/tracking/__init__.py
@@ -169,7 +169,7 @@ class TrackingPlugin(octoprint.plugin.SettingsPlugin,
 		               ram=self._environment[b"hardware"][b"ram"])
 
 		if self._helpers_get_throttle_state:
-			payload[b"throttle_state"] = self._helpers_get_throttle_state()
+			payload[b"throttle_state"] = self._helpers_get_throttle_state(raw_value_only=True)
 
 		if b"plugins" in self._environment and b"pi_support" in self._environment[b"plugins"]:
 			payload[b"pi_model"] = self._environment[b"plugins"][b"pi_support"][b"model"]
@@ -263,15 +263,18 @@ class TrackingPlugin(octoprint.plugin.SettingsPlugin,
 
 		server = self._settings.get([b"server"])
 		url = server.format(id=self._settings.get([b"unique_id"]), event=event)
+		# don't print the URL or uuid! That would expose the uuid in forums if pasted.
+		# (it's okay for the user to know their uuid, but it shouldn't be shared)
 
 		headers = {"User-Agent": "OctoPrint/{}".format(get_octoprint_version_string())}
 		try:
 			params = urlencode(kwargs, doseq=True).replace("+", "%20")
+
 			requests.get(url,
 			             params=params,
 			             timeout=3.1,
 			             headers=headers)
-			self._logger.info("Sent tracking event to {}, params: {}".format(url, kwargs))
+			self._logger.info("Sent tracking event to /{}, params: {}".format(event, kwargs))
 		except:
 			if self._logger.isEnabledFor(logging.DEBUG):
 				self._logger.exception("Error while sending event to anonymous usage tracking".format(url))

--- a/tests/plugins/pi_support/test_pi_support.py
+++ b/tests/plugins/pi_support/test_pi_support.py
@@ -150,4 +150,5 @@ class ThrottleStateTestCase(unittest.TestCase):
 		                                           current_overheat=False,
 		                                           past_overheat=True,
 		                                           current_issue=True,
-		                                           past_issue=True))
+		                                           past_issue=True,
+		                                           raw_value=-1))


### PR DESCRIPTION
- weave the throttle_state through pi_support and tracking. This should come in handy to see how many throttled Pis are out there, as well as if it is correllated with canceled prints.
- upgraded disclosure of tracking information so it shows as INFO-level in the logs and all the information is dumped. If tracking.octoprint.org gets it, I should have it too :)
