### PR TITLE
Prevent installing on python 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -218,6 +218,9 @@ def params():
 			"octoprint = octoprint:main"
 		]
 	}
+	
+	# Don't install on python 3
+	python_requires = '<3'
 
 	return locals()
 

--- a/src/octoprint/__main__.py
+++ b/src/octoprint/__main__.py
@@ -2,6 +2,10 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function
 
+import sys
+if sys.version_info[0] >= 3:
+	raise Exception("Octoprint does not support Python 3")
+
 if __name__ == "__main__":
 	import octoprint
 	octoprint.main()


### PR DESCRIPTION
Right now, it installs, and then just explodes at runtime.


Fixes https://github.com/foosel/OctoPrint/issues/2881