### PR TITLE
py23 compat: preventing unicode errors in python3

### DIFF
--- a/src/octoprint/cli/client.py
+++ b/src/octoprint/cli/client.py
@@ -12,6 +12,10 @@ import octoprint_client
 from octoprint.cli import get_ctx_obj_option, bulk_options
 from octoprint import init_settings, FatalStartupError
 
+try:
+	unicode
+except:
+	unicode =str
 
 class JsonStringParamType(click.ParamType):
 	name = "json"

--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -447,7 +447,7 @@ class FileManager(object):
 	def list_files(self, destinations=None, path=None, filter=None, recursive=None):
 		if not destinations:
 			destinations = self._storage_managers.keys()
-		if isinstance(destinations, (str, unicode, basestring)):
+		if isinstance(destinations, basestring):
 			destinations = [destinations]
 
 		result = dict()

--- a/src/octoprint/filemanager/storage.py
+++ b/src/octoprint/filemanager/storage.py
@@ -1033,7 +1033,7 @@ class LocalFileStorage(StorageInterface):
 	def path_in_storage(self, path):
 		if isinstance(path, (tuple, list)):
 			path = self.join_path(*path)
-		if isinstance(path, (str, unicode, basestring)):
+		if isinstance(path, basestring):
 			path = to_unicode(path)
 			if path.startswith(self.basefolder):
 				path = path[len(self.basefolder):]

--- a/src/octoprint/logging/__init__.py
+++ b/src/octoprint/logging/__init__.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import absolute_import
 
+from past.builtins import basestring
+
 from octoprint.logging import handlers
 
 def log_to_handler(logger, handler, level, msg, exc_info=None, extra=None, *args):
@@ -120,7 +122,7 @@ def get_divider_line(c, message=None, length=78, indent=3):
 		formatted divider line
 	"""
 
-	assert isinstance(c, (str, unicode, bytes)), "c is not text"
+	assert isinstance(c, basestring), "c is not text"
 	assert len(c) == 1, "c is not a single character"
 	assert isinstance(length, int), "length is not an int"
 	assert isinstance(indent, int), "indent is not an int"
@@ -128,7 +130,7 @@ def get_divider_line(c, message=None, length=78, indent=3):
 	if message is None:
 		return c * length
 
-	assert isinstance(message, (str, unicode, bytes)), "message is not text"
+	assert isinstance(message, basestring), "message is not text"
 
 	space = length - 2 * (indent + 1)
 	if space >= len(message):

--- a/src/octoprint/plugins/softwareupdate/scripts/update-octoprint.py
+++ b/src/octoprint/plugins/softwareupdate/scripts/update-octoprint.py
@@ -11,6 +11,11 @@ import sys
 import traceback
 import time
 
+try:
+	unicode
+except:
+	unicode = str
+
 def _log_call(*lines):
 	_log(lines, prefix=">", stream="call")
 

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -16,6 +16,10 @@ import threading
 import time
 
 from past.builtins import basestring
+try:
+	unicode
+except:
+	unicode = str
 
 from frozendict import frozendict
 

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -24,7 +24,10 @@ import tornado.util
 
 import octoprint.util
 
-
+try:
+	unicode
+except:
+	unicode = str
 
 def fix_json_encode():
 	"""

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -1497,7 +1497,7 @@ class Settings(object):
 			return value
 		if isinstance(value, (int, float)):
 			return value != 0
-		if isinstance(value, (str, unicode)):
+		if isinstance(value, basestring):
 			return value.lower() in valid_boolean_trues
 		return value is not None
 

--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -31,6 +31,10 @@ except ImportError:
 	import Queue as queue
 
 from past.builtins import basestring
+try:
+	unicode
+except:
+	unicode = str
 
 logger = logging.getLogger(__name__)
 

--- a/src/octoprint/vendor/sockjs/tornado/util.py
+++ b/src/octoprint/vendor/sockjs/tornado/util.py
@@ -2,6 +2,11 @@ import sys
 
 PY3 = sys.version_info[0] == 3
 
+try:
+	unicode
+except:
+	unicode = str
+
 if PY3:
     MAXSIZE = sys.maxsize
 


### PR DESCRIPTION
in py3 unicode does not exists is default str type but it exists in py2, wrote code to make it run in both py2 and py3

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
py2 has unicode but py3 does not
using basestring where posible
where not possible defining unicode = str

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
