### PR TITLE
py23 compat: cannot compare number with None

### DIFF
--- a/src/octoprint/printer/estimation.py
+++ b/src/octoprint/printer/estimation.py
@@ -189,10 +189,10 @@ class TimeEstimationHelper(object):
 		self._totals = collections.deque([], self._rolling_window)
 		self._sum_total = 0
 		self._count = 0
-		self._stable_counter = None
+		self._stable_counter = -1
 
 	def is_stable(self):
-		return self._stable_counter is not None and self._stable_counter >= self._countdown
+		return self._stable_counter >= self._countdown
 
 	def update(self, new_estimate):
 		old_average_total = self.average_total
@@ -205,12 +205,9 @@ class TimeEstimationHelper(object):
 			self._distances.append(abs(self.average_total - old_average_total))
 
 		if -1.0 * self._threshold < self.average_distance < self._threshold:
-			if self._stable_counter is None:
-				self._stable_counter = 0
-			else:
-				self._stable_counter += 1
+			self._stable_counter += 1
 		else:
-			self._stable_counter = None
+			self._stable_counter = -1
 
 		if self.is_stable():
 			return self.average_total_rolling
@@ -220,7 +217,7 @@ class TimeEstimationHelper(object):
 	@property
 	def average_total(self):
 		if not self._count:
-			return -1
+			return 0
 		else:
 			return self._sum_total / self._count
 

--- a/src/octoprint/printer/estimation.py
+++ b/src/octoprint/printer/estimation.py
@@ -220,20 +220,20 @@ class TimeEstimationHelper(object):
 	@property
 	def average_total(self):
 		if not self._count:
-			return None
+			return -1
 		else:
 			return self._sum_total / self._count
 
 	@property
 	def average_total_rolling(self):
 		if not self._count or self._count < self._rolling_window:
-			return None
+			return -1
 		else:
 			return sum(self._totals) / len(self._totals)
 
 	@property
 	def average_distance(self):
 		if not self._count or self._count < self._rolling_window + 1:
-			return None
+			return -1
 		else:
 			return sum(self._distances) / len(self._distances)

--- a/tests/printer/test_estimation.py
+++ b/tests/printer/test_estimation.py
@@ -35,8 +35,8 @@ class EstimationTestCase(unittest.TestCase):
 		self.assertEqual(self.estimation_helper.average_total, expected)
 
 	@data(
-		((1.0, 2.0), None),                    # not enough values, have 1, need 3
-		((1.0, 2.0, 3.0), None),               # not enough values, have 2, need 3
+		((1.0, 2.0), -1),                      # not enough values, have 1, need 3
+		((1.0, 2.0, 3.0), -1),                 # not enough values, have 2, need 3
 		((1.0, 2.0, 3.0, 4.0), 0.5),           # average totals: 1.0, 1.5, 2.0, 2.5 => (3 * 0.5 / 3 = 0.5
 		((1.0, 2.0, 3.0, 4.0, 5.0), 0.5),      # average totals: 1.0, 1.5, 2.0, 2.5, 3.0 => (0.5 + 0.5 + 0.5) / 3 = 0.5
 		((1.0, 2.0, 0.0, 1.0, 2.0), 0.7 / 3)   # average totals: 1.0, 1.5, 1.0, 1.0, 1.2 => (0.5 + 0.0 + 0.2) / 3 = 0.7 / 3
@@ -49,7 +49,7 @@ class EstimationTestCase(unittest.TestCase):
 		self.assertEqual(self.estimation_helper.average_distance, expected)
 
 	@data(
-		((1.0, 1.0), None),
+		((1.0, 1.0), -1),
 		((1.0, 1.0, 1.0), 1.0),
 		((1.0, 2.0, 3.0, 4.0, 5.0), 4.0),
 	)


### PR DESCRIPTION
TypeError: '<' not supported between instances of 'float' and 'NoneType'

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
TypeError: '<' not supported between instances of 'int' and 'NoneType'
TypeError: '<' not supported between instances of 'float' and 'NoneType'
in python3 comparison between non numeric types is not allowed anymore
replacing None with -1

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
