### PR TITLE
py23 compat: setting encoding and  future import for all the files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 #
 # OctoPrint documentation build configuration file, created by
 # sphinx-quickstart on Mon Dec 02 17:08:50 2013.

--- a/docs/sphinxext/codeblockext.py
+++ b/docs/sphinxext/codeblockext.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'The MIT License <http://opensource.org/licenses/MIT>'

--- a/docs/sphinxext/onlineinclude.py
+++ b/docs/sphinxext/onlineinclude.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'The MIT License <http://opensource.org/licenses/MIT>'

--- a/run
+++ b/run
@@ -1,4 +1,6 @@
 #!/usr/bin/env python2
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 import os
 import sys
@@ -8,12 +10,12 @@ basedir = os.path.dirname(os.path.realpath(__file__))
 old = os.path.join(basedir, "octoprint")
 if os.path.exists(old):
     # rename left-overs from old file structure
-    print """
+    print("""
 Found left-overs from old file structure, renaming to
 "octoprint.backup". Please remove this manually (I don't
 dare to do so myself since you might have changes in there
 I don't know anything about).
-"""
+""")
     os.rename(old, os.path.join(basedir, "octoprint.backup"))
 
 sys.path.insert(0, os.path.join(basedir, "src"))

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 from setuptools import setup, find_packages
 from distutils.command.build_py import build_py as _build_py

--- a/src/octoprint/_version.py
+++ b/src/octoprint/_version.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
@@ -9,7 +11,6 @@
 # versioneer-0.15+dev (https://github.com/warner/python-versioneer)
 
 """Git implementation of _version.py."""
-from __future__ import absolute_import, division, print_function
 
 import errno
 import os

--- a/src/octoprint/daemon.py
+++ b/src/octoprint/daemon.py
@@ -1,11 +1,12 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Generic linux daemon base class
 
 Originally from http://www.jejik.com/articles/2007/02/a_simple_unix_linux_daemon_in_python/#c35
 """
 
-from __future__ import absolute_import, division, print_function
 import sys, os, time, signal
 
 class Daemon:

--- a/src/octoprint/environment.py
+++ b/src/octoprint/environment.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2017 The OctoPrint Project - Released under terms of the AGPLv3 License"

--- a/src/octoprint/filemanager/destinations.py
+++ b/src/octoprint/filemanager/destinations.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function
+
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 
 class FileDestinations(object):

--- a/src/octoprint/logging/__init__.py
+++ b/src/octoprint/logging/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 from octoprint.logging import handlers
 

--- a/src/octoprint/logging/handlers.py
+++ b/src/octoprint/logging/handlers.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 import logging.handlers
 import os

--- a/src/octoprint/plugin/__init__.py
+++ b/src/octoprint/plugin/__init__.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 This module represents OctoPrint's plugin subsystem. This includes management and helper methods as well as the
 registered plugin types.
@@ -12,8 +14,6 @@ registered plugin types.
 .. autoclass:: PluginSettings
    :members:
 """
-
-from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/src/octoprint/plugin/core.py
+++ b/src/octoprint/plugin/core.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 In this module resides the core data structures and logic of the plugin system. It is implemented in an OctoPrint-agnostic
 way and could be extracted into a separate Python module in the future.
@@ -19,8 +21,6 @@ way and could be extracted into a separate Python module in the future.
    :members:
 
 """
-
-from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/src/octoprint/plugin/types.py
+++ b/src/octoprint/plugin/types.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 This module bundles all of OctoPrint's supported plugin implementation types as well as their common parent
 class, :class:`OctoPrintPlugin`.
@@ -15,8 +17,6 @@ Please note that the plugin implementation types are documented in the section
    :members:
 
 """
-
-from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/src/octoprint/plugins/__init__.py
+++ b/src/octoprint/plugins/__init__.py
@@ -1,1 +1,4 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 # make our plugins testable

--- a/src/octoprint/plugins/softwareupdate/scripts/update-octoprint.py
+++ b/src/octoprint/plugins/softwareupdate/scripts/update-octoprint.py
@@ -1,4 +1,5 @@
 #!/bin/env python2
+# coding=utf-8
 from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Haeussge <osd@foosel.net>"

--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function
+
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 

--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 This module defines the interface for communicating with a connected printer.
 
@@ -14,8 +16,6 @@ abstracted version of the actual printer communication.
 .. autoclass:: PrinterCallback
    :members:
 """
-
-from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/src/octoprint/printer/profile.py
+++ b/src/octoprint/printer/profile.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 This module contains printer profile related code.
 
@@ -136,8 +138,6 @@ A printer profile is a ``dict`` of the following structure:
 
 .. autoclass:: InvalidProfileError
 """
-
-from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 This module holds the standard implementation of the :class:`PrinterInterface` and it helpers.
 """
-
-from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 This module represents OctoPrint's settings management. Within this module the default settings for the core
 application are defined and the instance of the :class:`Settings` is held, which offers getter and setter
@@ -16,8 +18,6 @@ of various types and the configuration file itself.
    :members:
    :undoc-members:
 """
-
-from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/src/octoprint/slicing/__init__.py
+++ b/src/octoprint/slicing/__init__.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 In this module the slicing support of OctoPrint is encapsulated.
 
@@ -11,8 +13,6 @@ In this module the slicing support of OctoPrint is encapsulated.
 .. autoclass:: SlicingManager
    :members:
 """
-
-from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/src/octoprint/slicing/exceptions.py
+++ b/src/octoprint/slicing/exceptions.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Slicing related exceptions.
 
@@ -25,8 +27,6 @@ Slicing related exceptions.
    :show-inheritance:
 
 """
-
-from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function
+
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 

--- a/src/octoprint/util/avr_isp/__init__.py
+++ b/src/octoprint/util/avr_isp/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function

--- a/src/octoprint/util/avr_isp/chipDB.py
+++ b/src/octoprint/util/avr_isp/chipDB.py
@@ -1,4 +1,6 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function
+
 avrChipDB = {
 	'ATMega1280': {
 		'signature': [0x1E, 0x97, 0x03],

--- a/src/octoprint/util/avr_isp/intelHex.py
+++ b/src/octoprint/util/avr_isp/intelHex.py
@@ -1,4 +1,6 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function
+
 import io
 from builtins import range
 

--- a/src/octoprint/util/avr_isp/ispBase.py
+++ b/src/octoprint/util/avr_isp/ispBase.py
@@ -1,4 +1,6 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function
+
 import os, struct, sys, time
 
 from serial import Serial

--- a/src/octoprint/util/avr_isp/stk500v2.py
+++ b/src/octoprint/util/avr_isp/stk500v2.py
@@ -1,4 +1,6 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function
+
 import os, struct, sys, time
 
 from serial import Serial

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function
+
 __author__ = "Gina Häußge <osd@foosel.net> based on work by David Braam"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
 __copyright__ = "Copyright (C) 2013 David Braam - Released under terms of the AGPLv3 License"

--- a/src/octoprint/util/dev.py
+++ b/src/octoprint/util/dev.py
@@ -1,8 +1,10 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 This module provides a bunch of utility methods and helpers FOR DEVELOPMENT ONLY.
 """
-from __future__ import absolute_import, division, print_function
+
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 
 import contextlib

--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function
+
 __author__ = "Gina Häußge <osd@foosel.net> based on work by David Braam"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2013 David Braam, Gina Häußge - Released under terms of the AGPLv3 License"

--- a/src/octoprint/util/piptestballoon/setup.py
+++ b/src/octoprint/util/piptestballoon/setup.py
@@ -1,6 +1,5 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function
-import os
-import sys
 
 """
 This "python package" doesn't actually install. This is intentional. It is merely
@@ -16,6 +15,9 @@ behaviour if no such environment variable is set) is sadly not going to work out
 with versions of pip > 8.0.0, which capture all stdout output regardless of used
 --verbose or --log flags.
 """
+
+import os
+import sys
 
 def produce_output(stream):
 	from distutils.command.install import install as cmd_install

--- a/src/octoprint/util/version.py
+++ b/src/octoprint/util/version.py
@@ -1,8 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 This module provides a bunch of utility methods and helpers for version handling.
 """
-from __future__ import absolute_import, division, print_function
 
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 

--- a/src/octoprint/vendor/__init__.py
+++ b/src/octoprint/vendor/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function

--- a/src/octoprint/vendor/sockjs/__init__.py
+++ b/src/octoprint/vendor/sockjs/__init__.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 try:
   __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:

--- a/src/octoprint/vendor/sockjs/tornado/__init__.py
+++ b/src/octoprint/vendor/sockjs/tornado/__init__.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 from .router import SockJSRouter
 from .conn import SockJSConnection

--- a/src/octoprint/vendor/sockjs/tornado/basehandler.py
+++ b/src/octoprint/vendor/sockjs/tornado/basehandler.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.basehandler
     ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/conn.py
+++ b/src/octoprint/vendor/sockjs/tornado/conn.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.conn
     ~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/migrate.py
+++ b/src/octoprint/vendor/sockjs/tornado/migrate.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.migrate
     ~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/periodic.py
+++ b/src/octoprint/vendor/sockjs/tornado/periodic.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.periodic
     ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/proto.py
+++ b/src/octoprint/vendor/sockjs/tornado/proto.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.proto
     ~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/router.py
+++ b/src/octoprint/vendor/sockjs/tornado/router.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.router
     ~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/session.py
+++ b/src/octoprint/vendor/sockjs/tornado/session.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.session
     ~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/sessioncontainer.py
+++ b/src/octoprint/vendor/sockjs/tornado/sessioncontainer.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.sessioncontainer
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/static.py
+++ b/src/octoprint/vendor/sockjs/tornado/static.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.static
     ~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/stats.py
+++ b/src/octoprint/vendor/sockjs/tornado/stats.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 from collections import deque
 
 from tornado import ioloop

--- a/src/octoprint/vendor/sockjs/tornado/transports/__init__.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/__init__.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 import octoprint.vendor.sockjs.tornado.transports.pollingbase
 

--- a/src/octoprint/vendor/sockjs/tornado/transports/base.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/base.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 from octoprint.vendor.sockjs.tornado import session
 
 

--- a/src/octoprint/vendor/sockjs/tornado/transports/eventsource.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/eventsource.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.transports.eventsource
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/transports/htmlfile.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/htmlfile.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.transports.htmlfile
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/transports/jsonp.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/jsonp.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.transports.jsonp
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/transports/pollingbase.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/pollingbase.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.transports.pollingbase
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/transports/rawwebsocket.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/rawwebsocket.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.transports.rawwebsocket
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/transports/streamingbase.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/streamingbase.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 from octoprint.vendor.sockjs.tornado.transports import pollingbase
 
 

--- a/src/octoprint/vendor/sockjs/tornado/transports/websocket.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/websocket.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.transports.websocket
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/transports/xhr.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/xhr.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.transports.xhr
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/transports/xhrstreaming.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/xhrstreaming.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
     sockjs.tornado.transports.xhrstreaming
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/octoprint/vendor/sockjs/tornado/util.py
+++ b/src/octoprint/vendor/sockjs/tornado/util.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 import sys
 
 PY3 = sys.version_info[0] == 3

--- a/src/octoprint/vendor/sockjs/tornado/websocket.py
+++ b/src/octoprint/vendor/sockjs/tornado/websocket.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 import tornado
 from tornado import escape, gen, websocket
 

--- a/tests/_fixups.py
+++ b/tests/_fixups.py
@@ -1,5 +1,5 @@
-
-
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 import sys
 

--- a/tests/access/__init__.py
+++ b/tests/access/__init__.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for octoprint.access
 """

--- a/tests/access/_plugins/permissions_plugin.py
+++ b/tests/access/_plugins/permissions_plugin.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 
 def plugin_permissions(components):

--- a/tests/access/groups/__init__.py
+++ b/tests/access/groups/__init__.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for octoprint.access.groups
 """

--- a/tests/access/groups/test_groupmanager.py
+++ b/tests/access/groups/test_groupmanager.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for octoprint.access.groups.GroupManager
 """

--- a/tests/access/test_permissions.py
+++ b/tests/access/test_permissions.py
@@ -1,8 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for octoprint.access.permissions
 """
-from __future__ import absolute_import, division, print_function
 
 import unittest
 import ddt

--- a/tests/access/users/__init__.py
+++ b/tests/access/users/__init__.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for octoprint.access.users
 """

--- a/tests/access/users/test_usermanager.py
+++ b/tests/access/users/test_usermanager.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for octoprint.users.UserManager
 """

--- a/tests/access/users/test_users.py
+++ b/tests/access/users/test_users.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for octoprint.users
 """

--- a/tests/filemanager/__init__.py
+++ b/tests/filemanager/__init__.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.filemanager.``.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/manual_tests/always_update.py
+++ b/tests/manual_tests/always_update.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 """
 Place in ~/.octoprint/plugins & restart server to test:

--- a/tests/plugin/__init__.py
+++ b/tests/plugin/__init__.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.plugin``.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/plugin/_plugins/another_ordered_hook_plugin.py
+++ b/tests/plugin/_plugins/another_ordered_hook_plugin.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 def callback(*args, **kwargs):
 	pass
 

--- a/tests/plugin/_plugins/deprecated_plugin.py
+++ b/tests/plugin/_plugins/deprecated_plugin.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 import octoprint.plugin
 

--- a/tests/plugin/_plugins/hook_plugin.py
+++ b/tests/plugin/_plugins/hook_plugin.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 
 def hook_startup():

--- a/tests/plugin/_plugins/mixed_plugin/__init__.py
+++ b/tests/plugin/_plugins/mixed_plugin/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/plugin/_plugins/one_ordered_hook_plugin.py
+++ b/tests/plugin/_plugins/one_ordered_hook_plugin.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 def callback(*args, **kwargs):
 	pass
 

--- a/tests/plugin/_plugins/settings_plugin.py
+++ b/tests/plugin/_plugins/settings_plugin.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 import octoprint.plugin
 

--- a/tests/plugin/_plugins/startup_plugin.py
+++ b/tests/plugin/_plugins/startup_plugin.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 import octoprint.plugin
 

--- a/tests/plugin/test_core.py
+++ b/tests/plugin/test_core.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 import unittest
 import mock
 import ddt

--- a/tests/plugin/test_types_blueprint.py
+++ b/tests/plugin/test_types_blueprint.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 import unittest
 import mock
 

--- a/tests/plugin/test_types_settings.py
+++ b/tests/plugin/test_types_settings.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 import unittest
 import mock
 

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for bundled plugins.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/plugins/pi_support/__init__.py
+++ b/tests/plugins/pi_support/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function

--- a/tests/plugins/pi_support/fakes/fake_vcgencmd.py
+++ b/tests/plugins/pi_support/fakes/fake_vcgencmd.py
@@ -1,2 +1,5 @@
 #!/usr/bin/env python2
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 print("throttled=0x50005")

--- a/tests/plugins/pi_support/test_pi_support.py
+++ b/tests/plugins/pi_support/test_pi_support.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 import unittest
 import ddt

--- a/tests/plugins/test_pluginmanager.py
+++ b/tests/plugins/test_pluginmanager.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for bundled plugin "PluginManager".
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/printer/__init__.py
+++ b/tests/printer/__init__.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.printer``.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/printer/test_estimation.py
+++ b/tests/printer/test_estimation.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function
+
 from octoprint.printer.estimation import TimeEstimationHelper
 
 __author__ = "Gina Häußge <osd@foosel.net>"

--- a/tests/server/__init__.py
+++ b/tests/server/__init__.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.server``.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/server/util/__init__.py
+++ b/tests/server/util/__init__.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.server.util``.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/server/util/test_flask.py
+++ b/tests/server/util/test_flask.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.server.util.flask``.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/server/util/test_tornado.py
+++ b/tests/server/util/test_tornado.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.server.util.tornado``.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/server/util/test_webassets.py
+++ b/tests/server/util/test_webassets.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.server.util.flask``.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/settings/__init__.py
+++ b/tests/settings/__init__.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.settings``.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Tests for OctoPrint's Settings class
 

--- a/tests/slicing/__init__.py
+++ b/tests/slicing/__init__.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.slicing``.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function
+
 import _fixups
 
 import unittest

--- a/tests/test_octoprint_setuptools.py
+++ b/tests/test_octoprint_setuptools.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 import unittest
 import ddt

--- a/tests/timelapse/__init__.py
+++ b/tests/timelapse/__init__.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.timelapse``.
 """
-
-from __future__ import absolute_import
 
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2016 The OctoPrint Project - Released under terms of the AGPLv3 License"

--- a/tests/timelapse/test_timelapse_helpers.py
+++ b/tests/timelapse/test_timelapse_helpers.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2016 The OctoPrint Project - Released under terms of the AGPLv3 License"

--- a/tests/timelapse/test_timelapse_renderjob.py
+++ b/tests/timelapse/test_timelapse_renderjob.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2016 The OctoPrint Project - Released under terms of the AGPLv3 License"

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -1,9 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function
+
 """
 Unit tests for ``octoprint.util``.
 """
-
-from __future__ import absolute_import
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'

--- a/tests/util/test_caseinsensitive_set.py
+++ b/tests/util/test_caseinsensitive_set.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2018 The OctoPrint Project - Released under terms of the AGPLv3 License"

--- a/tests/util/test_comm.py
+++ b/tests/util/test_comm.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 import unittest
 import mock

--- a/tests/util/test_jinja.py
+++ b/tests/util/test_jinja.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms of the AGPLv3 License"

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2017 The OctoPrint Project - Released under terms of the AGPLv3 License"

--- a/tests/util/test_pip.py
+++ b/tests/util/test_pip.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2017 The OctoPrint Project - Released under terms of the AGPLv3 License"

--- a/tests/util/test_platform.py
+++ b/tests/util/test_platform.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
 __copyright__ = "Copyright (C) 2017 The OctoPrint Project - Released under terms of the AGPLv3 License"

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function
 
 # Version: 0.15+dev
 
@@ -369,7 +371,6 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 
 """
 
-from __future__ import print_function
 try:
     import configparser
 except ImportError:


### PR DESCRIPTION
# coding=utf-8
from __future__ import absolute_import, division, print_function

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
some files had encoding set some did not some had a different format
set all files with same encoding in same format

imported in all files (majority had but there were few that did not)
from __future__ import absolute_import, division, print_function

this will prepare to add unicode_literals later to the list and ensure py23 compatibility in all files

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
