### PR TITLE
py23 compat: click.disable_unicode_literals_warning = True

### DIFF
--- a/src/octoprint/cli/__init__.py
+++ b/src/octoprint/cli/__init__.py
@@ -6,6 +6,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 
 import click
+click.disable_unicode_literals_warning = True
 import octoprint
 import sys
 

--- a/src/octoprint/cli/analysis.py
+++ b/src/octoprint/cli/analysis.py
@@ -5,6 +5,7 @@ __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2017 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 import click
+click.disable_unicode_literals_warning = True
 
 #~~ "octoprint util" commands
 

--- a/src/octoprint/cli/client.py
+++ b/src/octoprint/cli/client.py
@@ -5,6 +5,7 @@ __license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 import click
+click.disable_unicode_literals_warning = True
 import json
 
 import octoprint_client

--- a/src/octoprint/cli/config.py
+++ b/src/octoprint/cli/config.py
@@ -6,6 +6,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 
 import click
+click.disable_unicode_literals_warning = True
 import logging
 
 from octoprint import init_settings, FatalStartupError

--- a/src/octoprint/cli/dev.py
+++ b/src/octoprint/cli/dev.py
@@ -7,6 +7,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 
 import click
+click.disable_unicode_literals_warning = True
 
 from past.builtins import basestring
 

--- a/src/octoprint/cli/plugins.py
+++ b/src/octoprint/cli/plugins.py
@@ -6,6 +6,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 
 import click
+click.disable_unicode_literals_warning = True
 import logging
 
 from octoprint.cli import pass_octoprint_ctx, OctoPrintContext, get_ctx_obj_option

--- a/src/octoprint/cli/server.py
+++ b/src/octoprint/cli/server.py
@@ -6,6 +6,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 
 import click
+click.disable_unicode_literals_warning = True
 import logging
 import sys
 

--- a/src/octoprint/plugins/softwareupdate/cli.py
+++ b/src/octoprint/plugins/softwareupdate/cli.py
@@ -7,6 +7,7 @@ __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms
 
 def commands(cli_group, pass_octoprint_ctx, *args, **kwargs):
 	import click
+	click.disable_unicode_literals_warning = True
 	import sys
 	import requests.exceptions
 	from octoprint.cli.client import create_client, client_options


### PR DESCRIPTION
when importing from future unicode literals those warning will need to be disabled

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
when we will do from __future__ import unicode literals, this flag will be needed
just harmless prep work for py3 support

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
