### PR TITLE
Use module name when loading plugins from entry points.

### DIFF
--- a/src/octoprint/plugin/core.py
+++ b/src/octoprint/plugin/core.py
@@ -839,12 +839,15 @@ class PluginManager(object):
 
 		# ... then create and return the real one
 		return self._import_plugin(key, *module,
-		                           name=name, version=version, summary=summary, author=author, url=url,
+		                           module_name=module_name, name=name, version=version, summary=summary, author=author, url=url,
 		                           license=license, bundled=bundled, parsed_metadata=plugin.parsed_metadata)
 
-	def _import_plugin(self, key, f, filename, description, name=None, version=None, summary=None, author=None, url=None, license=None, bundled=False, parsed_metadata=None):
+	def _import_plugin(self, key, f, filename, description, module_name=None, name=None, version=None, summary=None, author=None, url=None, license=None, bundled=False, parsed_metadata=None):
 		try:
-			instance = imp.load_module(key, f, filename, description)
+			if module_name:
+				instance = imp.load_module(module_name, f, filename, description)
+			else:
+				instance = imp.load_module(key, f, filename, description)
 			plugin = PluginInfo(key, filename, instance,
 			                    name=name,
 			                    version=version,


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Modules loaded from `$CONFIG/plugins/foobar.py` will be inserted into `sys.modules` under the name `foobar`, which seems reasonable under the circumstances.

Modules loaded from entry points [will be inserted into `sys.modules` (via `imp.load_module(...)`)](https://docs.python.org/2/library/imp.html#imp.load_module) under their identifier, *not* their package name, which can lead to some very weird and hard to debug problems.

For example, loading a hypothetical `octoprint_irc` plugin package will insert itself into `sys.modules['irc']`. After loading the plugin, any other code that runs `import irc` will actually import the `octoprint_irc` package, which is almost certainly not what the developer was expecting. To make matters worse:

 * Loading `octoprint_irc` by copying it to `$CONFIG/plugins` instead of using the entry points mechanism will make this bug disappear.
 * Attempting to `import irc` outside of OctoPrint, but in the same virtualenv, will correctly import a top-level module named `irc`.

I have modified the code in the simplest way I could think of, to make sure that modules loaded from entry points are inserted into `sys.modules` with their actual module name, which we know already. Essentially I made sure that the first argument to [`imp.find_module(...)`](https://github.com/foosel/OctoPrint/blob/112a8b9c8bf7f5895f6a29dbe3d98ea4d9e0f400/src/octoprint/plugin/core.py#L814-L817) was also used as the first argument to `imp.load_module(...)` when it is eventually called.

#### How was it tested? How can it be tested by the reviewer?

I ran the built-in tests (FWIW), and also installed a few random plugins from the repository to be sure they still installed properly and functioned.

I wrote a simple plugin to inspect `sys.modules`, and make sure the plugins I installed were being loaded under their module names and not their identifier.

#### Any background context you want to provide?

I ran in to this bug while writing a plugin to provide temperature data to InfluxDB. The plugin was named (unoriginally) `octoprint_influxdb`, and inside that package attempted to `import influxdb`. Without this fix, the package imported *itself*, and it took a while to figure out why because the bug disappears as soon as you take either entry points or the OctoPrint server out of the equation.

#### What are the relevant tickets if any?

I searched and could not find any previous run-ins with this bug.

#### Further notes

I am relatively unfamiliar with the OctoPrint codebase, and this bug strikes me as extremely subtle. It's possible my fix may cause issues I would not know how to test for. Somebody more familiar with the plugin system should take a look.