### PR TITLE
make login page responsive

### DIFF
--- a/src/octoprint/plugins/forcelogin/templates/forcelogin_index.jinja2
+++ b/src/octoprint/plugins/forcelogin/templates/forcelogin_index.jinja2
@@ -1,5 +1,6 @@
 <html>
 <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>OctoPrint Login</title>
 
     {% include "parts/forcelogin_css.jinja2" %}


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
with responsive plugins like TouchUI, all of the pages render on mobile just fine.. except the login page. I was tired of scrolling much wider than my phone's display (or zooming) to make it show up, so I did some investigation. Turns out it was just missing the meta viewport.

#### How was it tested? How can it be tested by the reviewer?
Just check out the login page on mobile now.

#### Any background context you want to provide?
na

#### What are the relevant tickets if any?
na

#### Screenshots (if appropriate)

Nonresponsive login on Server A:
![2019-01-02 20 00 14](https://user-images.githubusercontent.com/97914/50623312-36ac7d00-0ec9-11e9-8e48-36898f702c23.png)


Responsive login on Server B:
![2019-01-02 20 00 04](https://user-images.githubusercontent.com/97914/50623313-36ac7d00-0ec9-11e9-8281-d2674493957f.png)



#### Further notes
