### PR TITLE
add Z-axis to extruder offsets

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -94,6 +94,7 @@ date of first contribution):
   * [Gaston Dombiak](https://github.com/gdombiak)
   * [Brad Fisher](https://github.com/bradcfisher)
   * [Aldo Hoeben](https://github.com/fieldofview)
+  * [Roland Mieslinger](https://github.com/rmie)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/printer/profile.py
+++ b/src/octoprint/printer/profile.py
@@ -221,7 +221,7 @@ class PrinterProfileManager(object):
 		extruder=dict(
 			count = 1,
 			offsets = [
-				(0, 0)
+				(0, 0, 0)
 			],
 			nozzleDiameter = 0.4,
 			sharedNozzle = False
@@ -506,7 +506,7 @@ class PrinterProfileManager(object):
 			modified = True
 
 		if "extruder" in profile and "sharedNozzle" in profile["extruder"] and profile["extruder"]["sharedNozzle"]:
-			profile["extruder"]["offsets"] = [(0.0, 0.0)]
+			profile["extruder"]["offsets"] = [(0.0, 0.0, 0.0)]
 			modified = True
 
 		return modified
@@ -604,12 +604,16 @@ class PrinterProfileManager(object):
 		# validate offsets
 		offsets = []
 		for offset in profile["extruder"]["offsets"]:
-			if not len(offset) == 2:
+			if len(offset) == 2:
+				x_offset, y_offset = offset
+				z_offset = 0
+			elif len(offset) == 3:
+				x_offset, y_offset, z_offset = offset
+			else:
 				self._logger.warn("Profile has an invalid extruder.offsets entry: {entry!r}".format(entry=offset))
 				return False
-			x_offset, y_offset = offset
 			try:
-				offsets.append((float(x_offset), float(y_offset)))
+				offsets.append((float(x_offset), float(y_offset), float(z_offset)))
 			except:
 				self._logger.warn("Profile has an extruder.offsets entry with non-float values: {entry!r}".format(entry=offset))
 				return False

--- a/src/octoprint/static/js/app/viewmodels/printerprofiles.js
+++ b/src/octoprint/static/js/app/viewmodels/printerprofiles.js
@@ -23,7 +23,7 @@ $(function() {
             extruder: {
                 count: 1,
                 offsets: [
-                    [0,0]
+                    [0,0,0]
                 ],
                 nozzleDiameter: 0.4,
                 sharedNozzle: false
@@ -102,7 +102,8 @@ $(function() {
                     extruderOffsets[i] = {
                         idx: i + 1,
                         x: ko.observable(0),
-                        y: ko.observable(0)
+                        y: ko.observable(0),
+                        z: ko.observable(0)
                     }
                 }
                 self.extruderOffsets(extruderOffsets);
@@ -219,7 +220,8 @@ $(function() {
                     offsets.push({
                         idx: index + 1,
                         x: ko.observable(offset[0]),
-                        y: ko.observable(offset[1])
+                        y: ko.observable(offset[1]),
+                        z: ko.observable(offset[2])
                     });
                 });
             }
@@ -272,7 +274,7 @@ $(function() {
                 extruder: {
                     count: parseInt(self.extruders()),
                     offsets: [
-                        [0.0, 0.0]
+                        [0.0, 0.0, 0.0]
                     ],
                     nozzleDiameter: validFloat(self.nozzleDiameter(), defaultProfile.extruder.nozzleDiameter),
                     sharedNozzle: self.sharedNozzle()
@@ -306,7 +308,8 @@ $(function() {
                     if (i < self.extruderOffsets().length) {
                         offsetX = validFloat(self.extruderOffsets()[i]["x"](), 0.0);
                         offsetY = validFloat(self.extruderOffsets()[i]["y"](), 0.0);
-                        offset = [offsetX, offsetY];
+                        offsetZ = validFloat(self.extruderOffsets()[i]["z"](), 0.0);
+                        offset = [offsetX, offsetY, offsetZ];
                     }
                     profile.extruder.offsets.push(offset);
                 }

--- a/src/octoprint/templates/snippets/settings/printerprofiles/profileEditorExtruder.jinja2
+++ b/src/octoprint/templates/snippets/settings/printerprofiles/profileEditorExtruder.jinja2
@@ -45,6 +45,11 @@
                         <input type="number" step="0.01" class="input-mini text-right" data-bind="value: y" placeholder="0">
                         <span class="add-on">mm</span>
                     </div>
+                    <label>Z</label>
+                    <div class="input-append">
+                        <input type="number" step="0.01" class="input-mini text-right" data-bind="value: z" placeholder="0">
+                        <span class="add-on">mm</span>
+                    </div>
                 </div>
             </div>
             <!-- /ko -->

--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -435,11 +435,13 @@ class gcode(object):
 				else:
 					pos.x -= offsets[currentExtruder][0] if currentExtruder < len(offsets) else 0
 					pos.y -= offsets[currentExtruder][1] if currentExtruder < len(offsets) else 0
+					pos.z -= offsets[currentExtruder][2] if currentExtruder < len(offsets) else 0
 
 					currentExtruder = T
 
 					pos.x += offsets[currentExtruder][0] if currentExtruder < len(offsets) else 0
 					pos.y += offsets[currentExtruder][1] if currentExtruder < len(offsets) else 0
+					pos.z += offsets[currentExtruder][2] if currentExtruder < len(offsets) else 0
 
 					if len(currentE) <= currentExtruder:
 						for i in range(len(currentE), currentExtruder + 1):


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This PR adds Z-axis offset for multi extruder systems. While current multi extrusion system usually require all tools to have the same height, upcoming solutions like E3D's tool changer can have a slight deviation between extruders wrt. Z height.

#### How was it tested? How can it be tested by the reviewer?
automated tests: 718 passed, 6 skipped (Windows specific)

#### Any background context you want to provide?
This is part of my effort to make a plugin available to support printers with tool changers

#### What are the relevant tickets if any?
n/a

#### Screenshots (if appropriate)
n/a

#### Further notes
