### PR TITLE
Fixup actual temperature parsing for CR-10 S Pro

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -1721,6 +1721,7 @@ class MachineCom(object):
 
 				##~~ temperature processing
 				elif ' T:' in line or line.startswith('T:') or ' T0:' in line or line.startswith('T0:') \
+						or '==T:' in line or '==B:' in line \
 						or ((' B:' in line or line.startswith('B:')) and not 'A:' in line):
 
 					if not disable_external_heatup_detection and not self._temperature_autoreporting \


### PR DESCRIPTION
The temperature updates from this printer look like this in the terminal output:

```
Recv:  ==T:20.00 /0.00 ==B:21.02 /0.00 @:0 B@:0
```

`regex_temp` knows how to extract the data from this line, but there is some different logic that gates running the regex that needs to know what else to look for. The result of this is that the temperature chart doesn't show any useful information for me.

This diff expands the gating logic to allow recognizing `==T:` as well as `T:`, and that allows the temperature graph to function.