### PR TITLE
Use non blocking I/O for writes to implement write timeout (take 2)

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -2475,13 +2475,13 @@ class MachineCom(object):
 				serial_obj = serial.Serial(str(port),
 				                           baudrates[0],
 				                           timeout=read_timeout,
-				                           write_timeout=10000,
+				                           write_timeout=0,
 				                           parity=serial.PARITY_ODD)
 			else:
 				serial_obj = serial.Serial(str(port),
 				                           baudrate,
 				                           timeout=read_timeout,
-				                           write_timeout=10000,
+				                           write_timeout=0,
 				                           parity=serial.PARITY_ODD)
 			serial_obj.close()
 			serial_obj.parity = serial.PARITY_NONE
@@ -3288,6 +3288,11 @@ class MachineCom(object):
 					self._errorValue = "Could not write to serial port"
 					self.close(is_error=True)
 					break
+				# if we have failed to write data after an initial retry then the printer/system
+				# may be busy, so give things a little time before we try again. Extend this
+				# period each time we fail until either we write the data or run out of retry attempts.
+				if passes > 1:
+					sleep((passes-1)/10.0)
 
 	##~~ command handlers
 


### PR DESCRIPTION

#### What does this PR do and why is it necessary?
Currently write timeouts are not really implemented (as they are set to 10000 seconds). The current code also has the unwanted side effect of causing the use of a select call (in the Linux PySerial library) even when a write does not need to block. This call to select can in some odd cases cause the write to block for the duration of the set timeout which in turn triggers a transmission error.

This change addresses both issues by allowing the use of the existing write retry code to handle timeouts and by using non-blocking write mode to avoid the use of select.

#### How was it tested? How can it be tested by the reviewer?
See the following discussion for details of various tests: https://discourse.octoprint.org/t/communication-timeout-when-uploading-to-sd-m105-not-being-sent/6136/13

#### Any background context you want to provide?
https://discourse.octoprint.org/t/communication-timeout-when-uploading-to-sd-m105-not-being-sent/6136/13

#### What are the relevant tickets if any?
#2996

#### Screenshots (if appropriate)

#### Further notes
The current PR contains code to make each re-transmission attempt wait an increasingly long time before retrying. This may not strictly be required. But it seems better than simply battering against a possibly full queue again and again, as this will allow a (small) amount of time for the queue to be emptied by the printer. But feel free to amend this code as you see fit. The actual delays used (0.1s per retry) is pretty arbitrary.