### PR TITLE
Exclusive serial access

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -96,6 +96,7 @@ date of first contribution):
   * [Aldo Hoeben](https://github.com/fieldofview)
   * [Henning Groß](https://github.com/hgross)
   * [Jubaleth](https://github.com/jubaleth)
+  * [Daniel Joyce](https://github.com/DanielJoyce)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -2541,19 +2541,18 @@ class MachineCom(object):
 
 			# connect to regular serial port
 			self._log("Connecting to: %s" % port)
-			if baudrate == 0:
-				baudrates = baudrateList()
-				serial_obj = serial.Serial(str(port),
-				                           baudrates[0],
-				                           timeout=read_timeout,
-				                           write_timeout=0,
-				                           parity=serial.PARITY_ODD)
-			else:
-				serial_obj = serial.Serial(str(port),
-				                           baudrate,
-				                           timeout=read_timeout,
-				                           write_timeout=0,
-				                           parity=serial.PARITY_ODD)
+
+			serial_port_args = {
+				"port": str(port),
+				"baudrate": baudrateList()[0] if baudrate == 0 else baudrate,
+				"timeout": read_timeout,
+				"write_timeout": 0,
+				"parity": serial.PARITY_ODD,
+				"exclusive": True
+			}
+
+			serial_obj = serial.Serial(**serial_port_args)
+
 			serial_obj.close()
 			serial_obj.parity = serial.PARITY_NONE
 			serial_obj.open()


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

Opens serial ports in exclusive mode on POSIX platforms. On windows only exclusive ( or None, in pyserial, which defaults to exclusive ) is allowed. On posix, services can share serial ports, but this makes little sens in an application designed to manage 3d printers.

#### How was it tested? How can it be tested by the reviewer?

All existing tests pass.

Not certain of the absolute best way to test just yet, investigating...

#### Any background context you want to provide?

Per web discussions, there seem to be outstanding warnings against having another process using the same serial port as octoprint. This is trivial to avoid on posix platforms as they support exclusive access to serial ports.

#### What are the relevant tickets if any?

#3033 

#### Screenshots (if appropriate)

#### Further notes

Not 100% if octoprint tries to open the same serial port multiple times. Investigating.
