### PR TITLE
Always show unfuzzy times for total print time and time left in tooltip

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -56,20 +56,20 @@ $(function() {
         self.titlePrintButton = ko.observable(self.TITLE_PRINT_BUTTON_UNPAUSED);
         self.titlePauseButton = ko.observable(self.TITLE_PAUSE_BUTTON_UNPAUSED);
 
-		var estimatedPrintTimeStringHlpr = function (fmt) {
+        var estimatedPrintTimeStringHlpr = function (fmt) {
             if (self.lastPrintTime())
                 return fmt(self.lastPrintTime());
             if (self.estimatedPrintTime())
                 return fmt(self.estimatedPrintTime());
             return "-";
-		}
+        }
         self.estimatedPrintTimeString = ko.pureComputed(function() {
-			return estimatedPrintTimeStringHlpr(self.settings.appearance_fuzzyTimes() ? formatFuzzyPrintTime : formatDuration);
+            return estimatedPrintTimeStringHlpr(self.settings.appearance_fuzzyTimes() ? formatFuzzyPrintTime : formatDuration);
         });
         self.estimatedPrintTimeExactString = ko.pureComputed(function() {
-			return estimatedPrintTimeStringHlpr(formatDuration);
+            return estimatedPrintTimeStringHlpr(formatDuration);
         });
-		self.byteString = ko.pureComputed(function() {
+        self.byteString = ko.pureComputed(function() {
             if (!self.filesize())
                 return "-";
             var filepos = self.filepos() ? formatSize(self.filepos()) : "-";
@@ -85,7 +85,7 @@ $(function() {
                 return "-";
             return formatDuration(self.printTime());
         });
-		var printTimeLeftStringHlpr = function (fmt) {
+        var printTimeLeftStringHlpr = function (fmt) {
             if (self.printTimeLeft() == undefined) {
                 if (!self.printTime() || !(self.isPrinting() || self.isPaused())) {
                     return "-";
@@ -95,12 +95,12 @@ $(function() {
             } else {
                 return fmt(self.printTimeLeft());
             }
-		}
+        }
         self.printTimeLeftString = ko.pureComputed(function() {
-			return printTimeLeftStringHlpr(self.settings.appearance_fuzzyTimes() ? formatFuzzyPrintTime : formatDuration);
+            return printTimeLeftStringHlpr(self.settings.appearance_fuzzyTimes() ? formatFuzzyPrintTime : formatDuration);
         });
         self.printTimeLeftExactString = ko.pureComputed(function() {
-			return printTimeLeftStringHlpr(formatDuration);
+            return printTimeLeftStringHlpr(formatDuration);
         });
         self.printTimeLeftOriginString = ko.pureComputed(function() {
             var value = self.printTimeLeftOrigin();

--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -86,7 +86,7 @@ $(function() {
             return formatDuration(self.printTime());
         });
         var printTimeLeftStringHlpr = function (fmt) {
-            if (self.printTimeLeft() == undefined) {
+            if (self.printTimeLeft() === undefined) {
                 if (!self.printTime() || !(self.isPrinting() || self.isPaused())) {
                     return "-";
                 } else {

--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -56,14 +56,20 @@ $(function() {
         self.titlePrintButton = ko.observable(self.TITLE_PRINT_BUTTON_UNPAUSED);
         self.titlePauseButton = ko.observable(self.TITLE_PAUSE_BUTTON_UNPAUSED);
 
-        self.estimatedPrintTimeString = ko.pureComputed(function() {
+		var estimatedPrintTimeStringHlpr = function (fmt) {
             if (self.lastPrintTime())
-                return self.settings.appearance_fuzzyTimes() ? formatFuzzyPrintTime(self.lastPrintTime()) : formatDuration(self.lastPrintTime());
+                return fmt(self.lastPrintTime());
             if (self.estimatedPrintTime())
-                return self.settings.appearance_fuzzyTimes() ? formatFuzzyPrintTime(self.estimatedPrintTime()) : formatDuration(self.estimatedPrintTime());
+                return fmt(self.estimatedPrintTime());
             return "-";
+		}
+        self.estimatedPrintTimeString = ko.pureComputed(function() {
+			return estimatedPrintTimeStringHlpr(self.settings.appearance_fuzzyTimes() ? formatFuzzyPrintTime : formatDuration);
         });
-        self.byteString = ko.pureComputed(function() {
+        self.estimatedPrintTimeExactString = ko.pureComputed(function() {
+			return estimatedPrintTimeStringHlpr(formatDuration);
+        });
+		self.byteString = ko.pureComputed(function() {
             if (!self.filesize())
                 return "-";
             var filepos = self.filepos() ? formatSize(self.filepos()) : "-";
@@ -79,16 +85,22 @@ $(function() {
                 return "-";
             return formatDuration(self.printTime());
         });
-        self.printTimeLeftString = ko.pureComputed(function() {
-            if (self.printTimeLeft() === undefined) {
+		var printTimeLeftStringHlpr = function (fmt) {
+            if (self.printTimeLeft() == undefined) {
                 if (!self.printTime() || !(self.isPrinting() || self.isPaused())) {
                     return "-";
                 } else {
                     return gettext("Still stabilizing...");
                 }
             } else {
-                return self.settings.appearance_fuzzyTimes() ? formatFuzzyPrintTime(self.printTimeLeft()) : formatDuration(self.printTimeLeft());
+                return fmt(self.printTimeLeft());
             }
+		}
+        self.printTimeLeftString = ko.pureComputed(function() {
+			return printTimeLeftStringHlpr(self.settings.appearance_fuzzyTimes() ? formatFuzzyPrintTime : formatDuration);
+        });
+        self.printTimeLeftExactString = ko.pureComputed(function() {
+			return printTimeLeftStringHlpr(formatDuration);
         });
         self.printTimeLeftOriginString = ko.pureComputed(function() {
             var value = self.printTimeLeftOrigin();

--- a/src/octoprint/templates/sidebar/state.jinja2
+++ b/src/octoprint/templates/sidebar/state.jinja2
@@ -10,10 +10,10 @@
 <!-- ko foreach: filament -->
 <span data-bind="text: 'Filament (' + name() + '): ', title: 'Filament usage for ' + name()"></span><strong data-bind="text: formatFilament(data())"></strong><br>
 <!-- /ko -->
-<span title="{{ _('Estimated total print time based on analysis of the file or past prints') }}">{{ _('Approx. Total Print Time') }}</span>: <strong data-bind="text: estimatedPrintTimeString"></strong><br>
+<span title="{{ _('Estimated total print time based on analysis of the file or past prints') }}">{{ _('Approx. Total Print Time') }}</span>: <strong data-bind="text: estimatedPrintTimeString, attr: {title: estimatedPrintTimeExactString}"></strong><br>
 <hr>
 <span title="{{ _('Total print time so far') }}">{{ _('Print Time') }}</span>: <strong data-bind="text: printTimeString"></strong><br>
-<span title="{{ _('Estimated time until the print job is done. This is only an estimate and accuracy depends heavily on various factors!') }}">{{ _('Print Time Left') }}</span>: <strong data-bind="text: printTimeLeftString"></strong> <span id="state_printtimeleft_popover" style="display: none" data-bind="visible: printTimeLeftOrigin, attr: {title: printTimeLeftOriginString}, css: printTimeLeftOriginClass">&#9679;</span><br>
+<span title="{{ _('Estimated time until the print job is done. This is only an estimate and accuracy depends heavily on various factors!') }}">{{ _('Print Time Left') }}</span>: <strong data-bind="text: printTimeLeftString, attr: {title: printTimeLeftExactString}"></strong> <span id="state_printtimeleft_popover" style="display: none" data-bind="visible: printTimeLeftOrigin, attr: {title: printTimeLeftOriginString}, css: printTimeLeftOriginClass">&#9679;</span><br>
 <span title="{{ _('Bytes printed vs total bytes of file') }}">{{ _('Printed') }}</span>: <strong data-bind="text: byteString"></strong><br>
 
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Aadd the unfuzzy time strings to "Approx. Total Print Time" and "Print Time Left:" in the printer status sidebar as the title attribute (tooltip / flyover).

#### How was it tested? How can it be tested by the reviewer?
Locally on one printer. Simply mouse over the existing time (fuzzy or exact) to have all your dreams come true.

#### Any background context you want to provide?
We talked about it!

#### What are the relevant tickets if any?
#3040 I suppose

#### Screenshots (if appropriate)
N/A

#### Further notes
