### PR TITLE
Fixed error in GCode viewer where multiple filaments available (e.g. …

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/gcode.js
+++ b/src/octoprint/static/js/app/viewmodels/gcode.js
@@ -568,7 +568,9 @@ $(function() {
                         output.push(gettext("Filament") + ": " + layer.filament[0].toFixed(2) + "mm");
                     } else {
                         for (var i = 0; i < layer.filament.length; i++) {
-                            output.push(gettext("Filament") + " (" + gettext("Tool") + " " + i + "): " + layer.filament[i].toFixed(2) + "mm");
+                            if (layer.filament[i] !== undefined) {
+                                output.push(gettext("Filament") + " (" + gettext("Tool") + " " + i + "): " + layer.filament[i].toFixed(2) + "mm");
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
When multiple filaments are available (e.g. using a Prusa MMU2), but you are printing with say filament 4 only, the GCode Viewer throws errors as it loops over all filaments set on the layer - the unused ones are undefined and an exception gets generated).  This causes the layer height slider to not get updated correctly.

#### How was it tested? How can it be tested by the reviewer?
Tested on with Prusa MK3 with MMU2.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)
N/A
#### Further notes
Fix is just to add check if filament is not undefined before using it