### PR TITLE
Fix python version detection on Debian testing/unstable

### DIFF
--- a/src/octoprint/util/version.py
+++ b/src/octoprint/util/version.py
@@ -121,6 +121,10 @@ def get_comparable_version(version_string, base=False):
 	if "-" in version_string:
 		version_string = version_string[:version_string.find("-")]
 
+	# Debian has the python version set to 2.7.15+ which is not PEP440 compliant (bug 914072)
+	if version_string.endswith("+"):
+		version_string = version_string[:-1]
+
 	version = pkg_resources.parse_version(version_string)
 
 	# A leading v is common in github release tags and old setuptools doesn't remove it.


### PR DESCRIPTION
The current 2.7 Python binary on Debian returns "2.7.15+" as its version, which
is not PEP440 compliant. Tthere is no feedback at all from Debian maintainers
regarding the bug report as of now:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=914072

This patch makes sure to drop any trailing '+' character in a version string.

Fixes #3049

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [ ] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [ ] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [ ] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [ ] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [ ] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
