### PR TITLE
Added ability to preview the current layer to be drawn

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -97,6 +97,7 @@ date of first contribution):
   * [Henning Groß](https://github.com/hgross)
   * [Jubaleth](https://github.com/jubaleth)
   * [Daniel Joyce](https://github.com/DanielJoyce)
+  * [Andy Qua](https://github.com/AndyQ)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/static/gcodeviewer/js/renderer.js
+++ b/src/octoprint/static/gcodeviewer/js/renderer.js
@@ -46,6 +46,7 @@ GCODE.renderer = (function(){
         modelCenter: {x: 0, y: 0},
         differentiateColors: true,
         showNextLayer: false,
+        showCurrentLayer: false,
         showPreviousLayer: false,
         showBoundingBox: false,
         showFullSize: false,
@@ -97,6 +98,9 @@ GCODE.renderer = (function(){
             if (layerNumStore < model.length) {
                 if (renderOptions['showNextLayer'] && layerNumStore < model.length - 1) {
                     drawLayer(layerNumStore + 1, 0, GCODE.renderer.getLayerNumSegments(layerNumStore + 1), true);
+                }
+                if (renderOptions['showCurrentLayer'] && layerNumStore < model.length) {
+                    drawLayer(layerNumStore, 0, GCODE.renderer.getLayerNumSegments(layerNumStore), true);
                 }
                 if (renderOptions['showPreviousLayer'] && layerNumStore > 0) {
                     drawLayer(layerNumStore - 1, 0, GCODE.renderer.getLayerNumSegments(layerNumStore - 1), true);
@@ -567,7 +571,8 @@ GCODE.renderer = (function(){
         var sizeRetractSpot = renderOptions["sizeRetractSpot"] * lineWidthFactor * 2;
 
         // alpha value (100% if current layer is being rendered, 30% otherwise)
-        var alpha = (renderOptions['showNextLayer'] || renderOptions['showPreviousLayer']) && isNotCurrentLayer ? 0.3 : 1.0;
+        // Note - If showing currently layer as preview - also render it at 30% and draw the progress over the top at 100%
+        var alpha = (renderOptions['showNextLayer'] || renderOptions['showCurrentLayer'] || renderOptions['showPreviousLayer']) && isNotCurrentLayer ? 0.3 : 1.0;
         
         var colorLine = {};
         var colorMove = {};

--- a/src/octoprint/static/js/app/viewmodels/gcode.js
+++ b/src/octoprint/static/js/app/viewmodels/gcode.js
@@ -52,6 +52,7 @@ $(function() {
         self.renderer_extrusionWidthEnabled = ko.observable(false);
         self.renderer_extrusionWidth = ko.observable(2);
         self.renderer_showNext = ko.observable(false);
+        self.renderer_showCurrent = ko.observable(false);
         self.renderer_showPrevious = ko.observable(false);
         self.renderer_syncProgress = ko.observable(true);
 
@@ -79,6 +80,7 @@ $(function() {
                 showFullSize: self.renderer_showFullSize(),
                 extrusionWidth: self.renderer_extrusionWidthEnabled() ? self.renderer_extrusionWidth() : 1,
                 showNextLayer: self.renderer_showNext(),
+                showCurrentLayer: self.renderer_showCurrent(),
                 showPreviousLayer: self.renderer_showPrevious(),
                 zoomInOnModel: self.renderer_zoomOnModel(),
                 onInternalOptionChange: self._onInternalRendererOptionChange
@@ -124,6 +126,7 @@ $(function() {
         self.renderer_extrusionWidthEnabled.subscribe(self.rendererOptionUpdated);
         self.renderer_extrusionWidth.subscribe(self.rendererOptionUpdated);
         self.renderer_showNext.subscribe(self.rendererOptionUpdated);
+        self.renderer_showCurrent.subscribe(self.rendererOptionUpdated);
         self.renderer_showPrevious.subscribe(self.rendererOptionUpdated);
 
         self.reader_sortLayers.subscribe(self.readerOptionUpdated);
@@ -341,6 +344,7 @@ $(function() {
             self.renderer_extrusionWidthEnabled(false);
             self.renderer_extrusionWidth(2);
             self.renderer_showNext(false);
+            self.renderer_showCurrent(false);
             self.renderer_showPrevious(false);
             self.renderer_syncProgress(true);
 
@@ -711,6 +715,7 @@ $(function() {
             current["showRetracts"] = self.renderer_showRetracts();
             current["showPrinthead"] = self.renderer_showPrinthead();
             current["showPrevious"] = self.renderer_showPrevious();
+            current["showCurrent"] = self.renderer_showCurrent();
             current["showNext"] = self.renderer_showNext();
             current["showFullsize"] = self.renderer_showFullSize();
             current["showBoundingBox"] = self.renderer_showBoundingBox();
@@ -743,6 +748,7 @@ $(function() {
             if (current["showRetracts"] !== undefined) self.renderer_showRetracts(current["showRetracts"]) ;
             if (current["showPrinthead"] !== undefined) self.renderer_showPrinthead(current["showPrinthead"]);
             if (current["showPrevious"] !== undefined) self.renderer_showPrevious(current["showPrevious"]) ;
+            if (current["showCurrent"] !== undefined) self.renderer_showCurrent(current["showCurrent"]) ;
             if (current["showNext"] !== undefined) self.renderer_showNext(current["showNext"]) ;
             if (current["showFullsize"] !== undefined) self.renderer_showFullSize(current["showFullsize"]) ;
             if (current["showBoundingBox"] !== undefined) self.renderer_showBoundingBox(current["showBoundingBox"]) ;

--- a/src/octoprint/templates/tabs/gcodeviewer.jinja2
+++ b/src/octoprint/templates/tabs/gcodeviewer.jinja2
@@ -65,6 +65,9 @@
                     <input type="checkbox" data-bind="checked: renderer_showPrevious">{{ _('Also show previous layer') }}
                 </label>
                 <label class="checkbox">
+                    <input type="checkbox" data-bind="checked: renderer_showCurrent">{{ _('Also show current layer') }}
+                </label>
+                <label class="checkbox">
                     <input type="checkbox" data-bind="checked: renderer_showNext">{{ _('Also show next layer') }}
                 </label>
             </p>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This PR adds an additional option to then GCodeViewer to allow the current layer to be previewed as well as the next and previous layers.  If selected, it draws the full preview of the current layer at a 30% opacity and will then draw the progress over the top.  This allows the user to see how much of the current layer is remaining.

#### How was it tested? How can it be tested by the reviewer?
It was tested on a Raspberry PI with a Prusa MK3 printer and has been used on over 15 prints with no issues  so far.

#### Any background context you want to provide?
I made this change as I like seeing how much left of a layer is remaining - especially if I'm doing an additional manual filament change and want to pause at a specific point.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
