### PR TITLE
Add missing documentation about state in `jobs` endpoint

### DIFF
--- a/docs/api/datamodel.rst
+++ b/docs/api/datamodel.rst
@@ -219,6 +219,25 @@ Progress information
      - Integer
      - Estimate of time left to print, in seconds
 
+.. _sec-api-datamodel-jobs-state:
+
+State information
+-----------------
+
+.. list-table::
+   :widths: 15 5 10 30
+   :header-rows: 1
+
+   * - Name
+     - Multiplicity
+     - Type
+     - Description
+   * - body
+     - 1
+     - String
+     - A textual representation of the current state of the job, i.e. "Operational", "Printing", "Pausing", "Paused",
+       "Cancelling", "Error" or "Offline".
+
 .. _sec-api-datamodel-files:
 
 File related

--- a/docs/api/datamodel.rst
+++ b/docs/api/datamodel.rst
@@ -151,20 +151,6 @@ Temperature offset
 Job related
 ===========
 
-.. list-table::
-   :widths: 15 5 10 30
-   :header-rows: 1
-
-   * - Name
-     - Multiplicity
-     - Type
-     - Description
-   * - ``state``
-     - 1
-     - String
-     - A textual representation of the current state of the job, i.e. "Operational", "Printing", "Pausing", "Paused",
-       "Cancelling", "Error" or "Offline".
-
 .. _sec-api-datamodel-jobs-job:
 
 Job information

--- a/docs/api/datamodel.rst
+++ b/docs/api/datamodel.rst
@@ -151,6 +151,20 @@ Temperature offset
 Job related
 ===========
 
+.. list-table::
+   :widths: 15 5 10 30
+   :header-rows: 1
+
+   * - Name
+     - Multiplicity
+     - Type
+     - Description
+   * - ``state``
+     - 1
+     - String
+     - A textual representation of the current state of the job, i.e. "Operational", "Printing", "Pausing", "Paused",
+       "Cancelling", "Error" or "Offline".
+
 .. _sec-api-datamodel-jobs-job:
 
 Job information
@@ -218,25 +232,6 @@ Progress information
      - 1
      - Integer
      - Estimate of time left to print, in seconds
-
-.. _sec-api-datamodel-jobs-state:
-
-State information
------------------
-
-.. list-table::
-   :widths: 15 5 10 30
-   :header-rows: 1
-
-   * - Name
-     - Multiplicity
-     - Type
-     - Description
-   * - body
-     - 1
-     - String
-     - A textual representation of the current state of the job, i.e. "Operational", "Printing", "Pausing", "Paused",
-       "Cancelling", "Error" or "Offline".
 
 .. _sec-api-datamodel-files:
 

--- a/docs/api/job.rst
+++ b/docs/api/job.rst
@@ -246,5 +246,5 @@ Job information response
      - Information regarding the progress of the current print job
    * - ``state``
      - 1
-     - :ref:`sec-api-datamodel-jobs-state`
+     - :ref:`sec-api-datamodel-jobs`
      - Information regarding the state of the current print job

--- a/docs/api/job.rst
+++ b/docs/api/job.rst
@@ -246,5 +246,6 @@ Job information response
      - Information regarding the progress of the current print job
    * - ``state``
      - 1
-     - :ref:`sec-api-datamodel-jobs`
-     - Information regarding the state of the current print job
+     - String
+     - A textual representation of the current state of the job, i.e. "Operational", "Printing", "Pausing", "Paused",
+       "Cancelling", "Error" or "Offline".

--- a/docs/api/job.rst
+++ b/docs/api/job.rst
@@ -212,7 +212,8 @@ Retrieve information about the current job
           "filepos": 337942,
           "printTime": 276,
           "printTimeLeft": 912
-        }
+        },
+        "state": "Printing"
       }
 
    :statuscode 200: No error
@@ -243,4 +244,7 @@ Job information response
      - 1
      - :ref:`sec-api-datamodel-jobs-progress`
      - Information regarding the progress of the current print job
-
+   * - ``state``
+     - 1
+     - :ref:`sec-api-datamodel-jobs-state`
+     - Information regarding the state of the current print job


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

* checklist checked

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
This PR fixes the documentation of the `job` api endpoint. The current documentation omits the `state` member of the returned output. 

#### How was it tested? How can it be tested by the reviewer?
It is a documentation fix, no functional changes were made.

#### Further notes
The `state` member of the returned output is a string, not a structure. I am not sure if my additions to the documentation reflect that properly.