### PR TITLE
README: Use explicit python version for virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ you already have Python 2.7, pip and virtualenv set up on your system:
 
 1. Checkout OctoPrint: `git clone https://github.com/foosel/OctoPrint.git`
 2. Change into the OctoPrint folder: `cd OctoPrint`
-3. Create a user-owned virtual environment therein: `virtualenv venv`
+3. Create a user-owned virtual environment therein: `virtualenv venv` if your system default python version is
+   python 2.7, otherwise you need to specify the version explicitly, e.g. `virtualenv --python=python2.7 venv`.
 4. Install OctoPrint *into that virtual environment*: `./venv/bin/pip install .`
 
 You may then start the OctoPrint server via `/path/to/OctoPrint/venv/bin/octoprint`, see [Usage](#usage)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you enjoy OctoPrint, please consider becoming a regular supporter!**
 You are currently looking at the source code repository of OctoPrint. If you already installed it
 (e.g. by using the Raspberry Pi targeted distribution [OctoPi](https://github.com/guysoft/OctoPi)) and only
 want to find out how to use it, [the documentation](http://docs.octoprint.org/) and [the public wiki](https://github.com/foosel/OctoPrint/wiki)
-might be of more interest for you. You might also want to subscribe to join 
+might be of more interest for you. You might also want to subscribe to join
 [the community forum at community.octoprint.org](https://community.octoprint.org) where there are other active users who might be
 able to help you with any questions you might have.
 
@@ -39,7 +39,7 @@ able to help you with any questions you might have.
 
 Contributions of all kinds are welcome, not only in the form of code but also with regards to the
 [official documentation](http://docs.octoprint.org/) or [the public wiki](https://github.com/foosel/OctoPrint/wiki), debugging help
-in the [bug tracker](https://github.com/foosel/OctoPrint/issues), support of other users on 
+in the [bug tracker](https://github.com/foosel/OctoPrint/issues), support of other users on
 [the community forum at community.octoprint.org](https://community.octoprint.org)
 and also [financially](https://octoprint.org/support-octoprint/?utm_source=github&utm_medium=readme).
 
@@ -73,7 +73,7 @@ You may then start the OctoPrint server via `/path/to/OctoPrint/venv/bin/octopri
 for details.
 
 After installation, please make sure you follow the first-run wizard and set up
-access control as necessary. 
+access control as necessary.
 
 ## Dependencies
 


### PR DESCRIPTION
  * [ ] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)

This is actually a pull request explicitly targeting `master`.

#### What does this PR do and why is it necessary?

The current `README.md` on the `master` branch (which is the one people see when landing on the github page) suggest running `virtualenv venv` which will use python 3 when run on Fedora 29 and not create a usable environment.

The document do mention that only version 2.7 is supported, but it is not obvious that that requires an extra argument to virtualenv so it is best to show this explicitly.

#### How was it tested? How can it be tested by the reviewer?

I used that command when trying to run octoprint from the git repository.
