### PR TITLE
Add option for disabling filters on search results

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -99,6 +99,7 @@ date of first contribution):
   * [Daniel Joyce](https://github.com/DanielJoyce)
   * [Andy Qua](https://github.com/AndyQ)
   * [Fabio Santos](https://github.com/Fabi0San)
+  * [Jack Wilsdon](https://github.com/jackwilsdon)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -21,6 +21,7 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
     self.currentSorting = ko.observable(self.defaultSorting);
     self.currentFilters = ko.observableArray(self.defaultFilters);
     self.selectedItem = ko.observable(undefined);
+    self.filterSearch = ko.observable(true);
 
     self.storageIds = {
         "currentSorting": self.listType + "." + "currentSorting",
@@ -223,6 +224,19 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
 
     //~~ filtering
 
+    self.setFilterSearch = function(enabled) {
+        if (self.filterSearch() === enabled)
+            return;
+
+        self.filterSearch(enabled);
+        self.changePage(0);
+        self._updateItems();
+    };
+
+    self.toggleFilterSearch = function() {
+        self.setFilterSearch(!self.filterSearch());
+    };
+
     self.toggleFilter = function(filter) {
         if (!_.contains(_.keys(self.supportedFilters), filter))
             return;
@@ -283,15 +297,19 @@ function ItemListHelper(listType, supportedSorting, supportedFilters, defaultSor
         // work on all items
         var result = self.allItems;
 
-        // filter if necessary
-        var filters = self.currentFilters();
-        _.each(filters, function(filter) {
-            if (typeof filter !== 'undefined' && typeof supportedFilters[filter] !== 'undefined')
-                result = _.filter(result, supportedFilters[filter]);
-        });
+        var hasSearch = typeof self.searchFunction !== 'undefined' && self.searchFunction;
+
+        // filter if we're not searching or have search filtering enabled
+        if (!hasSearch || self.filterSearch()) {
+            var filters = self.currentFilters();
+            _.each(filters, function (filter) {
+                if (typeof filter !== 'undefined' && typeof supportedFilters[filter] !== 'undefined')
+                    result = _.filter(result, supportedFilters[filter]);
+            });
+        }
 
         // search if necessary
-        if (typeof self.searchFunction !== 'undefined' && self.searchFunction) {
+        if (hasSearch) {
             result = _.filter(result, self.searchFunction);
         }
 

--- a/src/octoprint/templates/sidebar/files_header.jinja2
+++ b/src/octoprint/templates/sidebar/files_header.jinja2
@@ -3,6 +3,8 @@
         <span class="fa fa-wrench"></span>
     </a>
     <ul class="dropdown-menu">
+        <li><a href="#" data-bind="click: function() { $root.listHelper.toggleFilterSearch(); }"><i class="fa fa-check" data-bind="style: {visibility: listHelper.filterSearch() ? 'visible' : 'hidden'}"></i> {{ _('Apply filters to search results') }}</a></li>
+        <li class="divider"></li>
         <li><a href="#" data-bind="click: function() { $root.listHelper.changeSorting('name'); }"><i class="fa fa-check" data-bind="style: {visibility: listHelper.currentSorting() == 'name' ? 'visible' : 'hidden'}"></i> {{ _('Sort by name') }} ({{ _('ascending') }})</a></li>
         <li><a href="#" data-bind="click: function() { $root.listHelper.changeSorting('upload'); }"><i class="fa fa-check" data-bind="style: {visibility: listHelper.currentSorting() == 'upload' ? 'visible' : 'hidden'}"></i> {{ _('Sort by upload date') }} ({{ _('descending') }})</a></li>
         <li><a href="#" data-bind="click: function() { $root.listHelper.changeSorting('size'); }"><i class="fa fa-check" data-bind="style: {visibility: listHelper.currentSorting() == 'size' ? 'visible' : 'hidden'}"></i> {{ _('Sort by file size') }} ({{ _('descending') }})</a></li>


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] ~~If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket~~
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] ~~If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)~~
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

This PR adds an option to allow filters to be turned on or off whilst searching;

!["File list settings" menu](https://user-images.githubusercontent.com/1843197/56458626-0a861080-6381-11e9-9993-2f1e0c1e928e.png)

This option defaults to keeping filters enabled as to not change any functionality.

#### How was it tested? How can it be tested by the reviewer?

1. Ensure that you have at least 2 files which can be shown/hidden with different filters (e.g. one successful print and one failed print)

    ![File list](https://user-images.githubusercontent.com/1843197/56458723-348c0280-6382-11e9-9357-dd5b00eb5325.png)

    You can use [these two files](https://gist.github.com/jackwilsdon/8a2a427b25b53ed4d8dfda76a8803832), which wait 10 and 5 seconds respectively (you should cancel the 10 second one to end up with a failed print).

2. Enable a filter which hides some files (in this example we're using a successful and failed print, so we enable "Hide successfully printed files")

    !["File list settings" menu](https://user-images.githubusercontent.com/1843197/56458626-0a861080-6381-11e9-9993-2f1e0c1e928e.png)

   ![Filtered file list](https://user-images.githubusercontent.com/1843197/56458761-816fd900-6382-11e9-9d39-f72fc6a9aefb.png)

3. Search for a file which is hidden by the filters (in this case `wait_5s.gcode`);

    ![Search results for "wait_5s.gcode"](https://user-images.githubusercontent.com/1843197/56458823-399d8180-6383-11e9-874a-1d390ad7b807.png)

4. Disable "Apply filters to search results"

    !["File list settings" menu](https://user-images.githubusercontent.com/1843197/56458847-897c4880-6383-11e9-8cad-aac0e264d805.png)

5. Note that previously filtered-out files are now shown

    ![Search results for "wait_5s.gcode" with "Apply filters to search results" turned off](https://user-images.githubusercontent.com/1843197/56458892-28a14000-6384-11e9-8b13-01dfb8b1c890.png)

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#2669 

#### Screenshots (if appropriate)

See testing section.

#### Further notes

Is maintenance the right place for this PR? The [contributing documentation](https://github.com/foosel/OctoPrint/blob/master/CONTRIBUTING.md#what-do-the-branches-mean) says this (emphasis mine):

> if it's a bug fix for a bug in the current stable version, _an improvement of existing functionality or a small new feature (e.g. a new hook, a new config flag, ...)_: `maintenance` branch

But the PR template says this (again emphasis mine):

>  Your PR targets OctoPrint's devel branch, _or maintenance if it's a bug fix for an issue present in the current stable version_ (no PRs against master or anything else please)