### PR TITLE
[Request] Allow subscriptions of multiple events

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -99,6 +99,7 @@ date of first contribution):
   * [Daniel Joyce](https://github.com/DanielJoyce)
   * [Andy Qua](https://github.com/AndyQ)
   * [Fabio Santos](https://github.com/Fabi0San)
+  * [Ryan Finnie](https://github.com/rfinnie)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -38,6 +38,13 @@ Example
      - event: PrintDone
        command: python ~/growl.py -t mygrowlserver -d "Completed {file}" -a OctoPrint -i http://raspi/Octoprint_logo.png
        type: system
+     - event:
+       - PrintStarted
+       - PrintFailed
+       - PrintDone
+       - PrintCancelled
+       command: python ~/growl.py -t mygrowlserver -d "Event {__eventname} ({name})" -a OctoPrint -i http://raspi/Octoprint_logo.png
+       type: system
      - event: Connected
        command:
        - M115
@@ -53,6 +60,7 @@ Placeholders
 You can use the following generic placeholders in your event hooks:
 
   * ``{__currentZ}``: the current Z position of the head if known, -1 if not available
+  * ``{__eventname}`` : the name of the event hook being triggered
   * ``{__filename}`` : name of currently selected file, or ``NO FILE`` if no file is selected
   * ``{__filepath}`` : path in origin location of currently selected file, or ``NO FILE`` if no file is selected
   * ``{__fileorigin}`` : origin of currently selected file, or ``NO FILE`` if no file is selected


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] ~~If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket~~
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] ~~If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)~~
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

Currently, each item in events > subscriptions[] must be a separate event, and if you have multiple similar subscribed events, they must be duplicated for each event.

With this PR, events > subscriptions[] > event may be either a string (existing functionality) or now a list of strings.  If a list, the subscriptions are treated the same for each event in the list.

To make it possible for command subscriptions to determine which event was triggered, a {__eventname} substitution has been added.

Quality of life change and strictly not necessary (you could run the same command against 10 different events by duplicating the subscription block 10 times.

#### How was it tested? How can it be tested by the reviewer?

Tested on local devel environment.  Existing unit tests run, but as there's not a test harness for events, no new tests were added.

Sample config:
```yaml
events:
  enabled: true
  subscriptions:
  - command: /usr/bin/touch "/tmp/foo-existing-Startup"
    event: Startup
    type: system
  - command: /usr/bin/touch "/tmp/foo-{__eventname}"
    event:
    - Startup
    - Shutdown
    - ClientOpened
    - ClientClosed
    - ConnectivityChanged
    type: system
```

#### Any background context you want to provide?

Background rationale: I wanted to touch a file in any state where a print was running and clear it when not running, for my external backup program to check so it could avoid starting a heavy backup while printing.  There are a number of events I wanted to check, but they all fell under either touch-type or rm-type events.

#### What are the relevant tickets if any?

N/A

#### Screenshots (if appropriate)

N/A

#### Further notes

N/A