### PR TITLE
Remote user support

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -101,6 +101,7 @@ date of first contribution):
   * [Fabio Santos](https://github.com/Fabi0San)
   * [Jack Wilsdon](https://github.com/jackwilsdon)
   * [Ryan Finnie](https://github.com/rfinnie)
+  * [Timur Duehr](https://github.com/tduehr)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -65,8 +65,8 @@ Use the following settings to enable access control:
      # Whether to trust remote user headers. If you have setup authentication in front of
      # OctoPrint and the user names you use there match OctoPrint accounts, by setting this to true users will
      # be logged into OctoPrint as the user provided in the header. Your should ONLY ENABLE THIS if your
-     # OctoPrint instance is only accessible through a connection locked down through an authenitating reverse proxy!
-     trustBasicAuthentication: false
+     # OctoPrint instance is only accessible through a connection locked down through an authenticating reverse proxy!
+     trustRemoteUser: false
 
      # Header used by the reverse proxy to convey the authenticated user.
      remoteUserHeader: REMOTE_USER

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -62,6 +62,18 @@ Use the following settings to enable access control:
      # header and login the user without further checks. Use with caution.
      checkBasicAuthenticationPassword: true
 
+     # Whether to trust remote user headers. If you have setup authentication in front of
+     # OctoPrint and the user names you use there match OctoPrint accounts, by setting this to true users will
+     # be logged into OctoPrint as the user provided in the header. Your should ONLY ENABLE THIS if your
+     # OctoPrint instance is only accessible through a connection locked down through an authenitating reverse proxy!
+     trustBasicAuthentication: false
+
+     # Header used by the reverse proxy to convey the authenticated user.
+     remoteUserHeader: REMOTE_USER
+
+     # If a remote user is not found, add them. Use this only if all users from the remote system can use OctoPrint.
+     addRemoteUsers: false
+
 .. _sec-configuration-config_yaml-api:
 
 API

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -147,8 +147,14 @@ def load_user(id):
 
 	return None
 
+
+def load_remote_user_from_request(request):
+	return util.get_user_for_remote_user_header(request)
+
+
 def load_user_from_request(request):
 	return util.get_user_for_authorization_header(request.headers.get('Authorization'))
+
 
 def unauthorized_user():
 	from flask import abort
@@ -1601,6 +1607,10 @@ class Server(object):
 		# login users authenticated by basic auth
 		if self._settings.get(["accessControl", "trustBasicAuthentication"]):
 			loginManager.request_callback = load_user_from_request
+
+		# Login via REMOTE_USER header
+		if self._settings.get(["accessControl", "useRemoteUser"]):
+			loginManager.request_callback = load_remote_user_from_request
 
 		if not userManager.enabled:
 			loginManager.anonymous_user = users.DummyUser

--- a/src/octoprint/server/util/__init__.py
+++ b/src/octoprint/server/util/__init__.py
@@ -199,6 +199,26 @@ def get_user_for_apikey(apikey):
 	return None
 
 
+def get_user_for_remote_user_header(request):
+	if not octoprint.server.userManager.enabled:
+		return None
+
+	if not settings().getBoolean(["accessControl", "trustRemoteUser"]):
+		return None
+
+	header = request.headers.get(settings().get(["accessControl", "remoteUserHeader"]))
+	if header is None:
+		return None
+
+	user = octoprint.server.userManager.findUser(userid=header)
+
+	if user is None and settings().getBoolean(["accessControl", "addRemoteUsers"]):
+		octoprint.server.userManager.addUser(header, settings().generateApiKey(), active=True)
+		user = octoprint.server.userManager.findUser(userid=header)
+
+	return user
+
+
 def get_user_for_authorization_header(header):
 	if not settings().getBoolean(["accessControl", "trustBasicAuthentication"]):
 		return None

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -337,7 +337,10 @@ default_settings = {
 		"localNetworks": ["127.0.0.0/8", "::1/128"],
 		"autologinAs": None,
 		"trustBasicAuthentication": False,
-		"checkBasicAuthenticationPassword": True
+		"checkBasicAuthenticationPassword": True,
+		"trustRemoteUser": False,
+		"remoteUserHeader": "REMOTE_USER",
+		"addRemoteUsers": False
 	},
 	"slicing": {
 		"enabled": True,

--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -1110,7 +1110,9 @@ $(function() {
                 + _.sprintf(gettext("Could not upload the file. Make sure that it is a readable, valid file with one of these extensions: %(extensions)s"),
                             {extensions: extensions})
                 + "</p>";
-            error += pnotifyAdditionalInfo("<pre>" + data.jqXHR.responseText + "</pre>");
+            if (data.jqXHR.responseText) {
+                error += pnotifyAdditionalInfo("<pre>" + data.jqXHR.responseText + "</pre>");
+            }
             new PNotify({
                 title: "Upload failed",
                 text: error,


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Adds basic support for users supplied by a reverse proxy (e.g., Apache, nginx) and automatically creating them if not found.

#### How was it tested? How can it be tested by the reviewer?
I'm not sure how to test it thoroughly, as I don't do much Python development. I'll be testing it against our SSO system. It should be testable the same way the Basic Authentication functionality is tested.

#### Any background context you want to provide?

Users want an increasing variety of authentication methods. Adding support for remote users opens up many of these (e.g., SAML, CAS, etc.) by pushing authentication to the reverse proxy (e.g., to Apache via `mod_auth_cas`). 

#### Further notes

This is only basic support, many remote user plugins (e.g., `mod_auth_cas`) support roles or groups as well.