### PR TITLE
Add autocofus to the username in the login plugin

### DIFF
--- a/src/octoprint/plugins/forcelogin/templates/forcelogin_index.jinja2
+++ b/src/octoprint/plugins/forcelogin/templates/forcelogin_index.jinja2
@@ -21,7 +21,7 @@
             <div id="login-error" class="alert alert-error">{{ _('Incorrect username or password.') }}</div>
             <div id="login-offline" class="alert alert-error">{{ _('Server is currently offline.') }} <a id="login-reconnect" href="javascript:void(0)">{{ _('Reconnect...') }}</a></div>
 
-            <input type="text" id="login-user" class="input-block-level" placeholder="{{ _('Username') }}">
+            <input type="text" id="login-user" class="input-block-level" placeholder="{{ _('Username') }}" autofocus>
             <input type="password" id="login-password" class="input-block-level" placeholder="{{ _('Password') }}">
             <label class="checkbox">
                 <input type="checkbox" id="login-remember"> {{ _('Remember me') }}


### PR DESCRIPTION
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)

#### What does this PR do and why is it necessary?
When I want to login, I need to focus to the username entry manually.
With autofocus, I can login more faster using only keyboard.

#### How was it tested? How can it be tested by the reviewer?
Tested on Firefox on my computer and on Firefox on Android.
Connect to Octoprint and the focus is automaticaly to the username entry.

