### PR TITLE
Added confirmation dialog before uninstalling plugin

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -102,6 +102,7 @@ date of first contribution):
   * [Jack Wilsdon](https://github.com/jackwilsdon)
   * [Ryan Finnie](https://github.com/rfinnie)
   * [Timur Duehr](https://github.com/tduehr)
+  * [Nicolai Nielsen](https://github.com/dovecode)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -120,6 +120,8 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 		self._repository_cache_ttl = self._settings.get_int(["repository_ttl"]) * 60
 		self._notices_cache_path = os.path.join(self.get_plugin_data_folder(), "notices.json")
 		self._notices_cache_ttl = self._settings.get_int(["notices_ttl"]) * 60
+		self._confirm_uninstall = self._settings.global_get_boolean(["confirm_uninstall"])
+		self._confirm_disable = self._settings.global_get_boolean(["confirm_disable"])
 
 		self._pip_caller = LocalPipCaller(force_user=self._settings.get_boolean(["pip_force_user"]))
 		self._pip_caller.on_log_call = self._log_call
@@ -157,6 +159,8 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 			notices_ttl=6*60,
 			pip_args=None,
 			pip_force_user=False,
+			confirm_uninstall=True,
+			confirm_disable=False,
 			dependency_links=False,
 			hidden=[]
 		)
@@ -167,6 +171,8 @@ class PluginManagerPlugin(octoprint.plugin.SimpleApiPlugin,
 		self._repository_cache_ttl = self._settings.get_int(["repository_ttl"]) * 60
 		self._notices_cache_ttl = self._settings.get_int(["notices_ttl"]) * 60
 		self._pip_caller.force_user = self._settings.get_boolean(["pip_force_user"])
+		self._confirm_uninstall = self._settings.global_get_boolean(["confirm_uninstall"])
+		self._confirm_disable = self._settings.global_get_boolean(["confirm_disable"])
 
 	##~~ AssetPlugin
 

--- a/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
+++ b/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
@@ -13,6 +13,8 @@ $(function() {
         self.config_noticesTtl = ko.observable();
         self.config_pipAdditionalArgs = ko.observable();
         self.config_pipForceUser = ko.observable();
+        self.config_confirmUninstall = ko.observable();
+        self.config_confirmDisable = ko.observable();
 
         self.configurationDialog = $("#settings_plugin_pluginmanager_configurationdialog");
 
@@ -394,12 +396,13 @@ $(function() {
                     .done(onSuccess)
                     .fail(onError);
             } else {
-                var perform = function() {
+                var performDisabling = function() {
                     OctoPrint.plugins.pluginmanager.disable(data.key)
                         .done(onSuccess)
                         .fail(onError);
                 };
 
+                // always warn if plugin is marked "disabling discouraged"
                 if (data.disabling_discouraged) {
                     var message = _.sprintf(gettext("You are about to disable \"%(name)s\"."), {name: data.name})
                         + "</p><p>" + data.disabling_discouraged;
@@ -409,10 +412,21 @@ $(function() {
                         question: gettext("Do you still want to disable it?"),
                         cancel: gettext("Keep enabled"),
                         proceed: gettext("Disable anyway"),
-                        onproceed: perform
-                    })
+                        onproceed: performDisabling
+                    });
+                }
+                // warn if global "warn disabling" setting is set"
+                else if (self.settingsViewModel.settings.plugins.pluginmanager.confirm_disable()) {
+                    showConfirmationDialog({
+                        message: _.sprintf(gettext("You are about to disable \"%(name)s\""), {name: data.name}),
+                        cancel: gettext("Keep enabled"),
+                        proceed: gettext("Disable plugin"),
+                        onproceed: performDisabling,
+                        nofade: true
+                    });
                 } else {
-                    perform();
+                    // otherwise just go ahead and disable...
+                    performDisabling();
                 }
             }
         };
@@ -511,23 +525,41 @@ $(function() {
             if (data.bundled) return;
             if (data.key == "pluginmanager") return;
 
-            self._markWorking(gettext("Uninstalling plugin..."), _.sprintf(gettext("Uninstalling plugin \"%(name)s\""), {name: data.name}));
+            // defining actual uninstall logic as functor in order to handle
+            // the confirm/no-confirm logic without duplication of logic
+            var performUninstall = function() {
+                self._markWorking(gettext("Uninstalling plugin..."), _.sprintf(gettext("Uninstalling plugin \"%(name)s\""), {name: data.name}));
 
-            OctoPrint.plugins.pluginmanager.uninstall(data.key)
-                .done(function() {
-                    self.requestData();
-                })
-                .fail(function() {
-                    new PNotify({
-                        title: gettext("Something went wrong"),
-                        text: gettext("Please consult octoprint.log for details"),
-                        type: "error",
-                        hide: false
+                OctoPrint.plugins.pluginmanager.uninstall(data.key)
+                    .done(function() {
+                        self.requestData();
+                    })
+                    .fail(function() {
+                        new PNotify({
+                            title: gettext("Something went wrong"),
+                            text: gettext("Please consult octoprint.log for details"),
+                            type: "error",
+                            hide: false
+                        });
+                    })
+                    .always(function() {
+                        self._markDone();
                     });
-                })
-                .always(function() {
-                    self._markDone();
+            };
+
+            if (self.settingsViewModel.settings.plugins.pluginmanager.confirm_uninstall()) {
+                // confirmation needed. Show confirmation dialog and call performUninstall if user clicks Yes
+                showConfirmationDialog({
+                    message: _.sprintf(gettext("You are about to uninstall the plugin \"%(name)s\""), {name: data.name}),
+                    cancel: gettext("Keep installed"),
+                    proceed: gettext("Uninstall"),
+                    onproceed: performUninstall,
+                    nofade: true
                 });
+            } else {
+                // no confirmation needed, just go ahead and uninstall
+                performUninstall();
+            }
         };
 
         self.refreshRepository = function() {
@@ -596,7 +628,9 @@ $(function() {
                         notices: notices,
                         notices_ttl: noticesTtl,
                         pip_args: pipArgs,
-                        pip_force_user: self.config_pipForceUser()
+                        pip_force_user: self.config_pipForceUser(),
+                        confirm_uninstall: self.config_confirmUninstall(),
+                        confirm_disable: self.config_confirmDisable(),
                     }
                 }
             };
@@ -614,6 +648,8 @@ $(function() {
             self.config_noticesTtl(self.settingsViewModel.settings.plugins.pluginmanager.notices_ttl());
             self.config_pipAdditionalArgs(self.settingsViewModel.settings.plugins.pluginmanager.pip_args());
             self.config_pipForceUser(self.settingsViewModel.settings.plugins.pluginmanager.pip_force_user());
+            self.config_confirmUninstall(self.settingsViewModel.settings.plugins.pluginmanager.confirm_uninstall());
+            self.config_confirmDisable(self.settingsViewModel.settings.plugins.pluginmanager.confirm_disable());
         };
 
         self.installed = function(data) {

--- a/src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2
+++ b/src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2
@@ -234,6 +234,25 @@
     </div>
     <div class="modal-body">
         <form class="form-horizontal">
+            <fieldset>
+                <legend>{{ _('Confirmations') }}</legend>
+
+                <div class="control-group" title="{{ _('Confirm before uninstalling a plugin') }}">
+                    <div class="controls">
+                        <label class="checkbox">
+                            <input type="checkbox" data-bind="checked: config_confirmUninstall"> {{ _('Confirm before uninstalling a plugin') }}
+                        </label>
+                    </div>
+                </div>
+                <div class="control-group" title="{{ _('Confirm before disabling a plugin') }}">
+                    <div class="controls">
+                        <label class="checkbox">
+                            <input type="checkbox" data-bind="checked: config_confirmDisable"> {{ _('Confirm before disabling a plugin') }}
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
+
             <p>{% trans %}You should normally <strong>not</strong> have to change <strong>any</strong> of the following settings, they are purely provided for convenience here.{% endtrans %}</p>
 
             <fieldset>


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch, or maintenance if it's
    a bug fix for an issue present in the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
Adding (optional) confirmation dialogs before uninstalling and disabling plugins. The former is to avoid accidentally uninstalling plugins. The latter because some (granted, broken) plugins behave badly when disabled.

The behavior is controlled with settings in the plugin manager and the default setting for both is "don't ask", i.e. the current behavior, in order to minimize disruption to existing users.

#### How was it tested? How can it be tested by the reviewer?

Tested by manual tests of the following use cases:

1. Start new server without changing settings and verify that neither disabling nor uninstalling results in a prompt (test defaults)

2. Change to enable prompting for uninstall and verify that the user is prompted when attempting to uninstall a plugin. Testing both branches (answering negatively leaves plugin, answering positively uninstalls)

3. Restart server, restart browser and try previous test case (tests correct persistence and reload of setting)

4. Change to enable prompting for disabling and verify that the user is prompted when attempting to disable a plugin. Testing both branches (answering negatively leaves plugin enabled, answering positively disables)

5. Re-enable plugin to verify that this path does not result in a prompt.

6. Restart server, restart browser and try previous test cases (tests correct persistence and reload of setting)

7. Disable both settings and test immediate results (no prompt for any action).

8. Restart server and browser and repeat previous test.

Note that several of the test cases run with `nosetests --with-doctest` do fail, but these are existing issues (same failures with a brand new `devel` branch checked out. This PR does nor fail more than `devel` ;)

Output from the test suite: `E.E....EEE..E..EF`

#### Any background context you want to provide?

Most of the changes (apart from persisting and loading settings) are UI changes. I don't believe we have a testing framework for this, so a lot of manual testing was necessary. I recommend commenting out the uninstall code and add a log statement when testing this to save time reinstalling plugins when testing the uninstall prompting logic.

I don't personally need the disable prompt, but it was mentioned in the linked ticket below so I included it, as it was a very simple addition.

As mentioned, I left defaults to not prompt so as to avoid disrupting existing users, but strictly speaking, the more robust solution would be to set the uninstall prompt to be enabled by default.

When I added the checkboxes for the settings, I added them at the top of the setting dialog for the plugin manager. This is because I don't believe the current caveat at the top ("You should normally not have to change any of the following settings, they are purely provided for convenience here.") apply to these settings -- they are purely user preferences. I am open for better ways to accomplish this.

#### What are the relevant tickets if any?

#2896 

#### Screenshots (if appropriate)

##### Uninstallation prompt

![Uninstallation prompt](https://user-images.githubusercontent.com/16987409/58375238-3ebe9500-7f1c-11e9-8941-382cac77e162.png)

##### Disabling prompt

![Disabling prompt](https://user-images.githubusercontent.com/16987409/58375230-2c445b80-7f1c-11e9-93c6-629fe9c3ab94.png)

##### iNew configuration dialog for the plugin manager

![iNew configuration dialog for the plugin manager](https://user-images.githubusercontent.com/16987409/58375216-074fe880-7f1c-11e9-8964-f8a7774aae9c.png)

#### Further notes

This PR adds screen prompts. I am unclear from the contribution guide as to whether I need to add them to a translation file anywhere, so I left the existing files unchanged. Do let me know if I need to take action on that.