### PR TITLE
Added button to terminal window to all log window to be cleared out

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/terminal.js
+++ b/src/octoprint/static/js/app/viewmodels/terminal.js
@@ -338,6 +338,14 @@ $(function() {
             copyToClipboard(lines.join("\n"));
         };
 
+        self.clearLogWidow = function() {
+            if (self.fancyFunctionality()) {
+                self.log([]);
+            } else {
+                self.plainLogLines([]);
+            }
+            
+        };
         // command matching regex
         // (Example output for inputs G0, G1, G28.1, M117 test)
         // - 1: code including optional subcode. Example: G0, G1, G28.1, M117

--- a/src/octoprint/static/js/app/viewmodels/terminal.js
+++ b/src/octoprint/static/js/app/viewmodels/terminal.js
@@ -338,13 +338,9 @@ $(function() {
             copyToClipboard(lines.join("\n"));
         };
 
-        self.clearLogWidow = function() {
-            if (self.fancyFunctionality()) {
-                self.log([]);
-            } else {
-                self.plainLogLines([]);
-            }
-            
+        self.clearAllLogs = function() {
+            self.log([]);
+            self.plainLogLines([]);            
         };
         // command matching regex
         // (Example output for inputs G0, G1, G28.1, M117 test)

--- a/src/octoprint/templates/tabs/terminal.jinja2
+++ b/src/octoprint/templates/tabs/terminal.jinja2
@@ -14,7 +14,7 @@
     </small>
     <small class="pull-right">
         <a href="javascript:void(0)" data-bind="click: copyAll"><i class="fa fa-copy" title="{{ _('Copy all') }}"></i> {{ _('Copy all') }}</a><br>
-        <a href="javascript:void(0)" data-bind="click: clearAllLogs"><i class="fa fa-copy" title="{{ _('Clear log window') }}"></i> {{ _('Clear log window') }}</a>
+        <a href="javascript:void(0)" data-bind="click: clearAllLogs"><i class="fa fa-trash-o" title="{{ _('Clear log window') }}"></i> {{ _('Clear all') }}</a>
     </small>
     <small class="pull-left text-warning" data-bind="visible: !fancyFunctionality()" style="display: none">
         {{ _('For performance reasons only a limited amount of terminal functionality is enabled right now.') }}

--- a/src/octoprint/templates/tabs/terminal.jinja2
+++ b/src/octoprint/templates/tabs/terminal.jinja2
@@ -13,7 +13,8 @@
         <span data-bind="visible: !autoscrollEnabled() && enableFancyFunctionality()" style="display: none">(<a href="javascript:void(0)" data-bind="click: scrollToEnd">{{ _("Scroll to end") }}</a>)</span>
     </small>
     <small class="pull-right">
-        <a href="javascript:void(0)" data-bind="click: copyAll"><i class="fa fa-copy" title="{{ _('Copy all') }}"></i> {{ _('Copy all') }}</a>
+        <a href="javascript:void(0)" data-bind="click: copyAll"><i class="fa fa-copy" title="{{ _('Copy all') }}"></i> {{ _('Copy all') }}</a><br>
+        <a href="javascript:void(0)" data-bind="click: clearLogWidow"><i class="fa fa-copy" title="{{ _('Clear log widow') }}"></i> {{ _('Clear log widow') }}</a>
     </small>
     <small class="pull-left text-warning" data-bind="visible: !fancyFunctionality()" style="display: none">
         {{ _('For performance reasons only a limited amount of terminal functionality is enabled right now.') }}

--- a/src/octoprint/templates/tabs/terminal.jinja2
+++ b/src/octoprint/templates/tabs/terminal.jinja2
@@ -14,7 +14,7 @@
     </small>
     <small class="pull-right">
         <a href="javascript:void(0)" data-bind="click: copyAll"><i class="fa fa-copy" title="{{ _('Copy all') }}"></i> {{ _('Copy all') }}</a><br>
-        <a href="javascript:void(0)" data-bind="click: clearLogWidow"><i class="fa fa-copy" title="{{ _('Clear log widow') }}"></i> {{ _('Clear log widow') }}</a>
+        <a href="javascript:void(0)" data-bind="click: clearAllLogs"><i class="fa fa-copy" title="{{ _('Clear log window') }}"></i> {{ _('Clear log window') }}</a>
     </small>
     <small class="pull-left text-warning" data-bind="visible: !fancyFunctionality()" style="display: none">
         {{ _('For performance reasons only a limited amount of terminal functionality is enabled right now.') }}


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This PR adds an addition button "Clear log window" to the terminal screen which allows the contents of the terminal window to be cleared out.
Whilst debugging other plugins, the logs can become quite tricky to find a specific place so its often useful to clear the existing logs before doing something which makes finding things a little simpler.

#### How was it tested? How can it be tested by the reviewer?
Populate Terminal log window either with output from Virtual printer or real connected printer.  Click the "Clear log window" button.  Existing log output should be cleared.

#### Any background context you want to provide?
N/A
#### What are the relevant tickets if any?
N/A
#### Screenshots (if appropriate)
N/A
#### Further notes
