### PR TITLE
Calculate filament usage for all extruders is M605 duplicate/mirror c…

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -105,6 +105,7 @@ date of first contribution):
   * [Jack Wilsdon](https://github.com/jackwilsdon)
   * [Ryan Finnie](https://github.com/rfinnie)
   * [Timur Duehr](https://github.com/tduehr)
+  * [Janne Mäntyharju](https://github.com/JanneMantyharju)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -220,6 +220,7 @@ class gcode(object):
 		totalMoveTimeMinute = 0.0
 		relativeE = False
 		relativeMode = False
+		duplicationMode = False
 		scale = 1.0
 		fwretractTime = 0
 		fwretractDist = 0
@@ -341,6 +342,14 @@ class gcode(object):
 						currentE[currentExtruder] += e
 						maxExtrusion[currentExtruder] = max(maxExtrusion[currentExtruder],
 						                                    totalExtrusion[currentExtruder])
+
+						if currentExtruder == 0 and len(currentE) > 1 and duplicationMode:
+ 							# Copy first extruder length to other extruders
+ 							for i in range(1, len(currentE)):
+ 								totalExtrusion[i] += e
+ 								currentE[i] += e
+ 								maxExtrusion[i] = max(maxExtrusion[i],
+ 						                          totalExtrusion[i])
 					else:
 						e = 0.0
 
@@ -428,6 +437,14 @@ class gcode(object):
 							fwretractDist = s
 						else:
 							fwrecoverTime = (fwretractDist + s) / f
+				elif M == 605:	#Duplication/Mirroring mode
+ 					s = getCodeInt(line, 'S')
+ 					if s in [2, 4, 5, 6]:
+ 						# Duplication / Mirroring mode selected. Printer firmware copies extrusion commands
+ 						# from first extruder to all other extruders
+ 						duplicationMode = True
+ 					else:
+ 						duplicationMode = False
 
 			elif T is not None:
 				if T > max_extruders:
@@ -476,7 +493,7 @@ class gcode(object):
 		            printing_area=self.printing_area)
 
 def getCodeInt(line, code):
-	return getCode(line, code, float)
+	return getCode(line, code, int)
 
 
 def getCodeFloat(line, code):


### PR DESCRIPTION
…ommand is used (Issue #3075)

#### What does this PR do and why is it necessary?
Some printers with more than one extruder support M605 command to duplicate or mirror what first extruder does. This change calculates the filament usage correctly for all extruders

#### How was it tested? How can it be tested by the reviewer?
Write M605 S2 to the beginning of gcode file (enable duplication mode). Do analysis and check that the filament usage is the same for all extruders.

#### Any background context you want to provide?

#### What are the relevant tickets if any?
#3075 
#### Screenshots (if appropriate)

#### Further notes
