### PR TITLE
fix RuntimeError: dictionary changed size during iteration

### DIFF
--- a/src/octoprint/server/api/printer.py
+++ b/src/octoprint/server/api/printer.py
@@ -525,7 +525,9 @@ def _delete_chamber(x):
 
 def _delete_from_data(x, key_matcher):
 	data = dict(x)
-	for k in data.keys():
+	# must make list of keys first to avoid
+	# RuntimeError: dictionary changed size during iteration
+	for k in list(data.keys()):
 		if key_matcher(k):
 			del data[k]
 	return data


### PR DESCRIPTION
This fixes a "RuntimeError: dictionary changed size during iteration".

It is necessary to create a temporary list object from the dictionary keys, so that as we delete items from the dictionary the iterator doesn't fail.

This absolutely fails on Python3, not sure if Python2 was more tolerant of the condition.

Fun fact...I'm running OctoPrint on a Pi3 with 64Bit OS and Python3.  Octoprint seems more snappy running under the 64-bit OS.  Python seems to like 64bits.  I have seen similar improvements running MyCroft on 64-bit OS.  I have even got a touchscreen panel running a custom Qt5 app on the device.
