### PR TITLE
Quote arguments in pip install

### DIFF
--- a/docs/development/environment.rst
+++ b/docs/development/environment.rst
@@ -25,7 +25,7 @@ below.
     ``source venv/Scripts/activate`` (Git Bash under Windows, see below)
   * Update ``pip`` in the virtual environment: ``pip install --upgrade pip``
   * Install OctoPrint in `"editable" mode <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_,
-    including its regular *and* development and plugin development dependencies: ``pip install -e .[develop,plugins]``
+    including its regular *and* development and plugin development dependencies: ``pip install -e '.[develop,plugins]'``
 
 When the virtual environment is activated you can then:
 


### PR DESCRIPTION
If the argument is not quoted, the shell will interpret the braces.
