### PR TITLE
added possibility to fire custom events from SockJS

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -105,6 +105,7 @@ date of first contribution):
   * [Jack Wilsdon](https://github.com/jackwilsdon)
   * [Ryan Finnie](https://github.com/rfinnie)
   * [Timur Duehr](https://github.com/tduehr)
+  * [Florian Horn](https://github.com/aurror)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/jsclientlib/socket.rst
+++ b/docs/jsclientlib/socket.rst
@@ -64,8 +64,14 @@
 
    Sends a message of type ``type`` with the provided ``payload`` to the server.
 
-   Note that at the time of writing, OctoPrint only supports the ``throttle`` message. See
-   also the :ref:`Push API documentation <sec-api-push>`.
+   Note that at the time of writing, OctoPrint supports the ``throttle`` and ``auth`` message as well as messages for registered custom events. See
+   also the :ref:`Push API documentation <sec-api-push>` and the :ref:`custom events hook <sec-plugins-hook-events-register_custom_events>`.
+
+   An example on how to use it with custom events is shown below:
+
+   .. code-block:: javascript
+
+      OctoPrint.socket.sendMessage("plugin_myplugin_my_custom_event", {"data": myData})
 
    :param string type: Type of message to send
    :param object payload: Payload to send

--- a/src/octoprint/events.py
+++ b/src/octoprint/events.py
@@ -26,6 +26,9 @@ _instance = None
 def all_events():
 	return [getattr(Events, name) for name in Events.__dict__ if not name.startswith("_") and not name in ("register_event",)]
 
+# return all custom events that were created using register_custom_events
+def custom_events():
+	return [getattr(Events, name) for name in Events.__dict__ if not name.startswith("_") and not name in ("register_event",) and name.startswith("PLUGIN_")]
 
 class Events(object):
 	# server

--- a/src/octoprint/server/util/sockjs.py
+++ b/src/octoprint/server/util/sockjs.py
@@ -209,6 +209,14 @@ class PrinterStateConnection(octoprint.vendor.sockjs.tornado.SockJSConnection,
 			else:
 				self._throttleFactor = throttle
 				self._logger.debug("Set throttle factor for client {} to {}".format(self._remoteAddress, self._throttleFactor))
+		else:
+			# handle custom events
+			for eventIdentfier in message:
+				registeredEvents = octoprint.events.custom_events()
+				if eventIdentfier in registeredEvents:
+					self._eventManager.fire(eventIdentfier, message[eventIdentfier])
+				else:
+					self._logger.warn("received SockJS message without an associated registered event: {} ".format(eventIdentfier))
 
 	def on_printer_send_current_data(self, data):
 		if not self._user.has_permission(Permissions.STATUS):


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
This PR adds the possibility to fire custom events from a SockJS connection.
This allows developers to send data from a SockJS client to a plugin they wrote, essentially allowing bidirectional communication since the plugin > SockJS direction was already possible, especially since the intoduction of custom events. 
This PR builds up on the custom events, making it possible to send data via SockJS to plugins, which can then react on it.

#### How was it tested? How can it be tested by the reviewer?
Manual testing by initializing a connection using the Javascript Client Library. I'm not sure how to include a test for the test suite in this case since it requires a socket connection.

**Note**: I tested it on the main branch, where it works and all unit tests pass. However, I could not connect or open the octoprint web interface on this devel branch (even without the code changes, looks like devel is broken atm).

#### Any background context you want to provide?
My initial requirement was to display a message box in OctoPrint when I press a button on a printer display. This could've been done by extending the API via the plugin, but since the introduction of custom events ( see [this original issue](https://github.com/foosel/OctoPrint/issues/2965), I thought it would be good to extend this functionality and allow SockJS Clients to communicate with plugins over these custom events. This makes it easy for developers to exchange or synchronize data between their octoprint plugin and e.g. a display connected to the printer or other custom functionality.

#### What are the relevant tickets if any?
See [my community post](https://community.octoprint.org/t/sending-data-via-socket-to-plugin/11070), my original idea was to send the data directly to the javascript side of the plugin, but afterwards I thought it would be better to send it to the python side and channel it through to the js side if necessary.

#### Further notes
Here's an example on how it can operate with a custom plugin and a SocketJS connection using the Javascript Client Library:

First register your custom events in your plugin
```
def register_custom_events(self, *args, **kwargs):
        return ["from_sockjs_to_plugin", "from_plugin_to_sockjs"]
```
Then you can start communication.

---

To send data from SockJS to your plugin, you can use
```
OctoPrint.socket.sendMessage("plugin_myplugin_from_sockjs_to_plugin", myJSONData })
```
and react on the plugin side on it by registering it for events using [the EventHandler Mixin](https://docs.octoprint.org/en/master/plugins/mixins.html#eventhandlerplugin) like this:
```
def on_event(self, event, payload):
        if (event == octoprint.events.Events.PLUGIN_MYPLUGIN_FROM_SOCKJS_TO_PYTHON):
                # ...
```


---


To send data from your plugin to SockJS:
```
self._event_bus.fire(octoprint.events.Events.PLUGIN_MYPLUGIN_FROM_PYTHON_TO_SOCKJS, myData)
```
and react on the SockJS side by registering 
```
OctoPrint.socket.onMessage("event", function(message) {
    if (message.data.type == "plugin_myplugin_from_python_to_sockjs")
    {
         // do something...
         // message.data.payload == myData
    }
});
```
**Note:** This is my first pull request, if something is wrong please tell me. :)

