### PR TITLE
All printer profile events are now triggered

### DIFF
--- a/src/octoprint/printer/profile.py
+++ b/src/octoprint/printer/profile.py
@@ -319,12 +319,19 @@ class PrinterProfileManager(object):
 		except InvalidProfileError:
 			return None
 
-	def remove(self, identifier):
+	def remove(self, identifier, trigger_event=False):
 		if self._current is not None and self._current["id"] == identifier:
 			return False
 		elif settings().get(["printerProfiles", "default"]) == identifier:
 			return False
-		return self._remove_from_path(self._get_profile_path(identifier))
+
+		removed = self._remove_from_path(self._get_profile_path(identifier))
+		if removed and trigger_event:
+			from octoprint.events import eventManager, Events
+			payload = dict(identifier=identifier)
+			eventManager().fire(Events.PRINTER_PROFILE_DELETED, payload=payload)
+
+		return removed
 
 	def save(self, profile, allow_overwrite=False, make_default=False, trigger_event=False):
 		if "id" in profile:
@@ -341,7 +348,10 @@ class PrinterProfileManager(object):
 		profile = dict_sanitize(profile, self.__class__.default)
 		profile = dict_merge(self.__class__.default, profile)
 
-		self._save_to_path(self._get_profile_path(identifier), profile, allow_overwrite=allow_overwrite)
+		path = self._get_profile_path(identifier)
+		is_overwrite = os.path.exists(path)
+
+		self._save_to_path(path, profile, allow_overwrite=allow_overwrite)
 
 		if make_default:
 			settings().set(["printerProfiles", "default"], identifier)
@@ -353,7 +363,8 @@ class PrinterProfileManager(object):
 		from octoprint.events import eventManager, Events
 		if trigger_event:
 			payload = dict(identifier=identifier)
-			eventManager().fire(Events.PRINTER_PROFILE_MODIFIED, payload=payload)
+			event = Events.PRINTER_PROFILE_MODIFIED if is_overwrite else Events.PRINTER_PROFILE_ADDED
+			eventManager().fire(event, payload=payload)
 
 		return self.get(identifier)
 

--- a/src/octoprint/server/api/printer_profiles.py
+++ b/src/octoprint/server/api/printer_profiles.py
@@ -85,7 +85,8 @@ def printerProfilesAdd():
 		return make_response("Profile does not contain mandatory 'name' field", 400)
 
 	try:
-		saved_profile = printerProfileManager.save(profile, allow_overwrite=False, make_default=make_default)
+		saved_profile = printerProfileManager.save(profile, allow_overwrite=False, make_default=make_default,
+												   trigger_event=True)
 	except InvalidProfileError:
 		return make_response("Profile is invalid", 400)
 	except CouldNotOverwriteError:
@@ -114,7 +115,7 @@ def printerProfilesDelete(identifier):
 	if default_profile and default_profile["id"] == identifier:
 		return make_response("Cannot delete default profile: {}".format(identifier), 409)
 
-	printerProfileManager.remove(identifier)
+	printerProfileManager.remove(identifier, trigger_event=True)
 	return NO_CONTENT
 
 @api.route("/printerprofiles/<string:identifier>", methods=["PATCH"])


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

Events PRINTER_PROFILE_ADDED and PRINTER_PROFILE_DELETED are now triggered. This PR completes the previous PR that added PRINTER_PROFILE_MODIFIED event.

#### How was it tested? How can it be tested by the reviewer?

Added, updated and delete a printer profile and here are the events published to the websocket.
![Screen Shot 2019-09-04 at 10 54 52 PM](https://user-images.githubusercontent.com/1791267/64315709-b1053380-cf67-11e9-851b-72047ba1eff0.png)

#### Any background context you want to provide?

Previous PR https://github.com/foosel/OctoPrint/pull/3249

#### What are the relevant tickets if any?

No tickets.

#### Screenshots (if appropriate)

#### Further notes
