### PR TITLE
Fix systemd service documentation path

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -109,6 +109,7 @@ date of first contribution):
   * [Aliaksei Pilko](https://github.com/aliaksei135)
   * [Ben Yarmis](https://github.com/byarmis)
   * [Florian Heilmann](https://github.com/FHeilmann)
+  * [Ludovico de Nittis](https://github.com/RyuzakiKK)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,5 +13,5 @@ octoprint.init      => /etc/init.d/octoprint
 ## systemd
 
 ```
-octoprint.service   => /etc/systemd/service/octoprint.service
+octoprint.service   => /etc/systemd/system/octoprint.service
 ```


### PR DESCRIPTION

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

In the `scripts/README.md` it was suggested to place the `octoprint.service` in the `/etc/systemd/service/` folder. But this folder doesn't exist.
Instead it is common practice to place services in `system`, as also suggested in the raspbian documentation for example.

#### How was it tested? How can it be tested by the reviewer?
```
$ sudo mv octoprint.service /etc/systemd/service/octoprint.service
mv: cannot move 'octoprint.service' to '/etc/systemd/service/octoprint.service': No such file or directory
$ sudo mv octoprint.service /etc/systemd/system/octoprint.service
$ sudo systemctl start octoprint.service
```
#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
