### PR TITLE
Fixed a doc typo in the restore command name of the Backup plugin

### DIFF
--- a/docs/bundledplugins/backup.rst
+++ b/docs/bundledplugins/backup.rst
@@ -27,7 +27,7 @@ Command line usage
 ------------------
 
 The Backup Plugin implements a command line interface that allows creation and restoration of backups.
-It adds two new commands, ``backup:backup`` and ``backup_restore``.
+It adds two new commands, ``backup:backup`` and ``backup:restore``.
 
 .. code-block:: none
 


### PR DESCRIPTION
This PR contains a single character typo fix in the documentation of the Backup plugin.
Thanks for reviewing! :)