### PR TITLE
Setting to allow gcode analysis to continue during printing

### DIFF
--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -19,7 +19,6 @@ from .analysis import QueueEntry, AnalysisQueue
 from .storage import LocalFileStorage
 from .util import AbstractFileWrapper, StreamWrapper, DiskFileWrapper
 from octoprint.util import get_fully_qualified_classname as fqcn
-from octoprint.settings import settings
 
 from collections import namedtuple
 
@@ -224,7 +223,9 @@ class FileManager(object):
 		self._progress_plugins = []
 		self._preprocessor_hooks = dict()
 
-		self._recovery_file = os.path.join(settings().getBaseFolder("data"), "print_recovery_data.yaml")
+		import octoprint.settings
+		self._recovery_file = os.path.join(octoprint.settings.settings().getBaseFolder("data"), "print_recovery_data.yaml")
+		self._analyzeGcode = octoprint.settings.settings().get(["gcodeAnalysis", "runAt"])
 
 	def initialize(self, process_backlog=False):
 		self.reload_plugins()
@@ -233,7 +234,7 @@ class FileManager(object):
 
 	def process_backlog(self):
 		# only check for a backlog if gcodeAnalysis is 'idle' or 'always'
-		if settings().get(["gcodeAnalysis", "runAt"]) == "never":
+		if self._analyzeGcode == "never":
 			return
 
 		def worker():

--- a/src/octoprint/filemanager/analysis.py
+++ b/src/octoprint/filemanager/analysis.py
@@ -176,7 +176,10 @@ class AbstractAnalysisQueue(object):
 		        (False, default)
 		"""
 
-		if high_priority:
+		if settings().get(["gcodeAnalysis", "runAt"]) == "never":
+			self._logger.debug("Ignoring entry {entry} for analysis queue".format(entry=entry))
+			return
+		elif high_priority:
 			self._logger.debug("Adding entry {entry} to analysis queue with high priority".format(entry=entry))
 			prio = self.__class__.HIGH_PRIO
 		else:

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1099,8 +1099,8 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 			self._analysisQueue.resume() # printing done, put those cpu cycles to good use
 
 		elif state == comm.MachineCom.STATE_PRINTING:
-			if settings().getBoolean(["gcodeAnalysis", "pauseDuringPrint"]):
-				self._analysisQueue.pause() # do not analyse files while printing
+			if settings().get(["gcodeAnalysis", "runAt"]) == "idle":
+				self._analysisQueue.pause() # only analyse files while idle
 
 		if state == comm.MachineCom.STATE_CLOSED or state == comm.MachineCom.STATE_CLOSED_WITH_ERROR:
 			if self._comm is not None:

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1099,7 +1099,8 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 			self._analysisQueue.resume() # printing done, put those cpu cycles to good use
 
 		elif state == comm.MachineCom.STATE_PRINTING:
-			self._analysisQueue.pause() # do not analyse files while printing
+			if settings().getBoolean(["gcodeAnalysis", "pauseDuringPrint"]):
+				self._analysisQueue.pause() # do not analyse files while printing
 
 		if state == comm.MachineCom.STATE_CLOSED or state == comm.MachineCom.STATE_CLOSED_WITH_ERROR:
 			if self._comm is not None:

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -134,6 +134,9 @@ def getSettings():
 			"g90InfluencesExtruder": s.getBoolean(["feature", "g90InfluencesExtruder"]),
 			"autoUppercaseBlacklist": s.get(["feature", "autoUppercaseBlacklist"])
 		},
+		"gcodeAnalysis": {
+			"runAt": s.get(["gcodeAnalysis", "runAt"])
+		},
 		"serial": {
 			"port": connectionOptions["portPreference"],
 			"baudrate": connectionOptions["baudratePreference"],
@@ -427,6 +430,9 @@ def _saveSettings(data):
 		if "printCancelConfirmation" in data["feature"]: s.setBoolean(["feature", "printCancelConfirmation"], data["feature"]["printCancelConfirmation"])
 		if "g90InfluencesExtruder" in data["feature"]: s.setBoolean(["feature", "g90InfluencesExtruder"], data["feature"]["g90InfluencesExtruder"])
 		if "autoUppercaseBlacklist" in data["feature"] and isinstance(data["feature"]["autoUppercaseBlacklist"], (list, tuple)): s.set(["feature", "autoUppercaseBlacklist"], data["feature"]["autoUppercaseBlacklist"])
+
+	if "gcodeAnalysis" in data:
+		if "runAt" in data["gcodeAnalysis"]: s.set(["gcodeAnalysis", "runAt"], data["gcodeAnalysis"]["runAt"])
 
 	if "serial" in data:
 		if "autoconnect" in data["serial"]: s.setBoolean(["serial", "autoconnect"], data["serial"]["autoconnect"])

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -258,7 +258,8 @@ default_settings = {
 		"maxExtruders": 10,
 		"throttle_normalprio": 0.01,
 		"throttle_highprio": 0.0,
-		"throttle_lines": 100
+		"throttle_lines": 100,
+		"pauseDuringPrint": True
 	},
 	"feature": {
 		"temperatureGraph": True,

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -259,7 +259,7 @@ default_settings = {
 		"throttle_normalprio": 0.01,
 		"throttle_highprio": 0.0,
 		"throttle_lines": 100,
-		"pauseDuringPrint": True
+		"runAt": "idle" # 'never', 'idle', 'always'
 	},
 	"feature": {
 		"temperatureGraph": True,

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -154,6 +154,8 @@ $(function() {
         self.feature_g90InfluencesExtruder = ko.observable(undefined);
         self.feature_autoUppercaseBlacklist = ko.observable(undefined);
 
+        self.gcodeAnalysis_runAt = ko.observable(undefined);
+
         self.serial_port = ko.observable();
         self.serial_baudrate = ko.observable();
         self.serial_exclusive = ko.observable();

--- a/src/octoprint/templates/dialogs/settings/features.jinja2
+++ b/src/octoprint/templates/dialogs/settings/features.jinja2
@@ -56,4 +56,19 @@
             <span class="help-block">{{ _('Use this to specify the commands that should not have their parameters automatically uppercased in the terminal tab. Just the G or M code, comma separated.') }}</span>
         </div>
     </div>
+
+    <div class="control-group">
+        <label class="control-label">{{ _('Analyze gcode for print time estimates')}}</label>
+        <div class="controls">
+            <label class="radio">
+                <input type="radio" name="analysisRunAtGroup" value="always" data-bind="checked: gcodeAnalysis_runAt" id="settings-gcodeAnalysis_runAtAlways"> {{ _('Always ') }}
+            </label>
+            <label class="radio">
+                <input type="radio" name="analysisRunAtGroup" value="idle" data-bind="checked: gcodeAnalysis_runAt" id="settings-gcodeAnalysis_runAtIdle"> {{ _('Only when idle (not printing)') }}
+            </label>
+            <label class="radio">
+                <input type="radio" name="analysisRunAtGroup" value="never" data-bind="checked: gcodeAnalysis_runAt" id="settings-gcodeAnalysis_runAtNever"> {{ _('Never') }}
+            </label>
+        </div>
+    </div>
 </form>

--- a/src/octoprint/templates/dialogs/settings/features.jinja2
+++ b/src/octoprint/templates/dialogs/settings/features.jinja2
@@ -58,7 +58,7 @@
     </div>
 
     <div class="control-group">
-        <label class="control-label">{{ _('Analyze gcode for print time estimates')}}</label>
+        <label class="control-label">{{ _('Analyze gcode for time and model size estimates')}}</label>
         <div class="controls">
             <label class="radio">
                 <input type="radio" name="analysisRunAtGroup" value="always" data-bind="checked: gcodeAnalysis_runAt" id="settings-gcodeAnalysis_runAtAlways"> {{ _('Always ') }}


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
GCODE analysis is great for providing a print time estimation, but currently you have to wait for analysis to finish before hitting the print button, because analysis can't run during printing by design. Since most users are on multicore systems (Pi 2 and above, or a PC) it is nice to use those extra cores to continue analysis during the print. This adds an option to `config.yaml -> gcodeAnalysis -> runAt: default=idle` to allow analysis to continue during printing to populate the time estimate or to disable analysis completely.

#### How was it tested? How can it be tested by the reviewer?
I've been running with this change for several years, hundreds of prints, no issues. The time estimate just pops in once the analysis completes. I've never seen any strange behavior of the two processes interacting poorly, or becoming wedged in a deadlock. 

#### Any background context you want to provide?
I think you're nice?

#### What are the relevant tickets if any?
None

#### Screenshots (if appropriate)
None

#### Further notes
Ideally, the code should allow the background analysis to switch throttle_lines or the priority mode of the already-running gcode process, but that would require some sort of IPC pipe to the analysis process and I felt that was too big a change for what would be very little benefit. There is plenty of CPU on a Pi3 to run both processes at full priority with no degradation to the gcode streaming/print functionality.

~~I also considered making the analysis process an enum `{ Never, OnlyWhenIdle, Always }` to allow the user to also completely block the analysis process entirely (i.e. never analyze files) but I don't think there's much of a use case for that. OnlyWhenIdle would be the current functionality, and Always would be the same as this patch with pauseDuringPrint=false.~~ This has been added