### PR TITLE
Do not refresh on no-cache in request

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -115,6 +115,7 @@ date of first contribution):
   * [Ludovico de Nittis](https://github.com/RyuzakiKK)
   * [Dominik Paľo](https://github.com/DominikPalo)
   * [Kelly Anderson](https://github.com/cbxbiker61)
+  * [Mike Ryan](https://github.com/justfalter)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/plugin/types.py
+++ b/src/octoprint/plugin/types.py
@@ -587,11 +587,10 @@ class UiPlugin(OctoPrintPlugin, SortablePlugin):
 	There are two methods used in order to allow for caching of the actual
 	response sent to the client. Whatever a plugin implementation returns
 	from the call to its :meth:`~octoprint.plugin.UiPlugin.on_ui_render` method
-	will be cached server side. The cache will be emptied in case of explicit
-	no-cache headers sent by the client, or if the ``_refresh`` query parameter
-	on the request exists and is set to ``true``. To prevent caching of the
-	response altogether, a plugin may set no-cache headers on the returned
-	response as well.
+	will be cached server side. The cache will be emptied if the ``_refresh``
+	query parameter on the request exists and is set to ``true``. To prevent
+	caching of the response altogether, a plugin may set no-cache headers on
+	the returned response as well.
 
 	``UiPlugin`` is a :class:`~octoprint.plugin.core.SortablePlugin` with a sorting context
 	for :meth:`~octoprint.plugin.UiPlugin.will_handle_ui`. The first plugin to return ``True``

--- a/src/octoprint/server/views.py
+++ b/src/octoprint/server/views.py
@@ -174,8 +174,8 @@ def index():
 	def wizard_active(templates):
 		return templates is not None and bool(templates["wizard"]["order"])
 
-	# we force a refresh if the client forces one or if we have wizards cached
-	force_refresh = util.flask.cache_check_headers() or "_refresh" in request.values or wizard_active(_templates.get(locale))
+	# we force a refresh if '_refresh' is in the query or if we have wizards cached
+	force_refresh = "_refresh" in request.values or wizard_active(_templates.get(locale))
 
 	# if we need to refresh our template cache or it's not yet set, process it
 	fetch_template_data(refresh=force_refresh)


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)


#### What does this PR do and why is it necessary?
Remove code that would lead to a refresh upon receiving a
'Cache-Control: no-cache' or 'Pragma: no-cache' in a request (like when a hard browser reload is performed via Control-Shift-R). The
purpose of these headers is to invalidate intermediate proxy caches, not
that of an application server. A refresh in octoprint would lead to
several seconds of high CPU utilization on lower-power systems (like the
Raspberry Pi), leading to stuttering in print jobs.

It was not clear to me why there would be the need for hard browser reloads (Control-Shift-R) to cause the application caches to be refreshed. The only reason I can think that this behavior would be desired would be during development of OctoPrint, not during production use. 

It is still possible to explicitly cause a refresh by including
`_refresh` in the query parameters of a request.

#### How was it tested? How can it be tested by the reviewer?
1. Enable debug logging
2. Execute `curl -o /dev/null  -H 'Cache-Control: no-cache' 'http://octoprint/` no longer leads to a refresh.
3. Observe that a cached entry is used to satisfy the request.

#### Any background context you want to provide?

See https://github.com/foosel/OctoPrint/issues/1241#issuecomment-556041037

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
